### PR TITLE
feat: add test fuzz CLI command for Move function fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6254,6 +6254,7 @@ dependencies = [
  "move-vm-types",
  "parking_lot 0.12.5",
  "prometheus",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ bincode = "1.3"
 prometheus = "0.13"
 parking_lot = "0.12"
 rayon = "1.10"
+rand = "0.8"
 better_any = "0.1"
 
 # Async runtime - pinned to match MystenLabs Sui crate requirements

--- a/crates/sui-sandbox-core/Cargo.toml
+++ b/crates/sui-sandbox-core/Cargo.toml
@@ -26,6 +26,7 @@ chrono.workspace = true
 uuid.workspace = true
 dirs.workspace = true
 rayon.workspace = true
+rand.workspace = true
 better_any.workspace = true
 parking_lot.workspace = true
 

--- a/crates/sui-sandbox-core/src/fuzz/classifier.rs
+++ b/crates/sui-sandbox-core/src/fuzz/classifier.rs
@@ -1,0 +1,429 @@
+//! Parameter classification for Move function fuzzing.
+//!
+//! Classifies each parameter of a Move function as pure (fuzzable),
+//! system-injected (auto-handled), object-based (Phase 2), or unfuzzable.
+
+use move_binary_format::file_format::SignatureToken;
+use move_binary_format::CompiledModule;
+use serde::{Deserialize, Serialize};
+
+/// Classification of a function parameter for fuzzing purposes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "class")]
+pub enum ParamClass {
+    /// Pure BCS value — fully fuzzable.
+    Pure { pure_type: PureType },
+    /// System-injected parameter — skipped by fuzzer, auto-handled by PTBExecutor.
+    SystemInjected { system_type: SystemType },
+    /// Object passed by reference — not fuzzable in Phase 1.
+    ObjectRef { mutable: bool, type_str: String },
+    /// Object passed by value — not fuzzable in Phase 1.
+    ObjectOwned { type_str: String },
+    /// Cannot be fuzzed (unresolved generics, complex patterns).
+    Unfuzzable { reason: String },
+}
+
+/// Pure value types that can be randomly generated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PureType {
+    Bool,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    U256,
+    Address,
+    VectorBool,
+    VectorU8,
+    VectorU16,
+    VectorU32,
+    VectorU64,
+    VectorU128,
+    VectorU256,
+    VectorAddress,
+    /// 0x1::string::String — BCS is vector<u8>
+    String,
+    /// 0x1::ascii::String — BCS is vector<u8>
+    AsciiString,
+}
+
+/// System types auto-injected by the PTB executor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SystemType {
+    TxContext,
+    MutTxContext,
+    Clock,
+}
+
+/// Result of classifying a function's parameters.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassifiedFunction {
+    /// Human-readable type string and classification for each parameter.
+    pub params: Vec<(String, ParamClass)>,
+    /// Whether all parameters are either Pure or SystemInjected.
+    pub is_fully_fuzzable: bool,
+    /// Count of pure (fuzzable) parameters.
+    pub pure_count: usize,
+    /// Count of system-injected parameters.
+    pub system_count: usize,
+    /// Count of object parameters (not fuzzable in Phase 1).
+    pub object_count: usize,
+    /// Count of unfuzzable parameters.
+    pub unfuzzable_count: usize,
+}
+
+/// Resolve a struct's fully-qualified name from a SignatureToken::Datatype index.
+fn resolve_struct_name(
+    module: &CompiledModule,
+    idx: &move_binary_format::file_format::DatatypeHandleIndex,
+) -> (String, String, String) {
+    let datatype_handle = &module.datatype_handles[idx.0 as usize];
+    let module_handle = &module.module_handles[datatype_handle.module.0 as usize];
+    let addr = module
+        .address_identifier_at(module_handle.address)
+        .to_hex_literal();
+    let mod_name = module.identifier_at(module_handle.name).to_string();
+    let type_name = module.identifier_at(datatype_handle.name).to_string();
+    (addr, mod_name, type_name)
+}
+
+/// Check if a resolved struct is TxContext.
+fn is_tx_context(addr: &str, mod_name: &str, type_name: &str) -> bool {
+    // TxContext lives at 0x2::tx_context::TxContext
+    (addr == "0x2" || addr == "0x0000000000000000000000000000000000000000000000000000000000000002")
+        && mod_name == "tx_context"
+        && type_name == "TxContext"
+}
+
+/// Check if a resolved struct is Clock.
+fn is_clock(addr: &str, mod_name: &str, type_name: &str) -> bool {
+    (addr == "0x2" || addr == "0x0000000000000000000000000000000000000000000000000000000000000002")
+        && mod_name == "clock"
+        && type_name == "Clock"
+}
+
+/// Check if a resolved struct is 0x1::string::String.
+fn is_string(addr: &str, mod_name: &str, type_name: &str) -> bool {
+    (addr == "0x1" || addr == "0x0000000000000000000000000000000000000000000000000000000000000001")
+        && mod_name == "string"
+        && type_name == "String"
+}
+
+/// Check if a resolved struct is 0x1::ascii::String.
+fn is_ascii_string(addr: &str, mod_name: &str, type_name: &str) -> bool {
+    (addr == "0x1" || addr == "0x0000000000000000000000000000000000000000000000000000000000000001")
+        && mod_name == "ascii"
+        && type_name == "String"
+}
+
+/// Format a SignatureToken as a human-readable type string.
+/// Mirrors `format_signature_token` in resolver.rs but is standalone.
+fn format_token(module: &CompiledModule, token: &SignatureToken) -> String {
+    match token {
+        SignatureToken::Bool => "bool".into(),
+        SignatureToken::U8 => "u8".into(),
+        SignatureToken::U16 => "u16".into(),
+        SignatureToken::U32 => "u32".into(),
+        SignatureToken::U64 => "u64".into(),
+        SignatureToken::U128 => "u128".into(),
+        SignatureToken::U256 => "u256".into(),
+        SignatureToken::Address => "address".into(),
+        SignatureToken::Signer => "signer".into(),
+        SignatureToken::Vector(inner) => format!("vector<{}>", format_token(module, inner)),
+        SignatureToken::Datatype(idx) => {
+            let (addr, mod_name, type_name) = resolve_struct_name(module, idx);
+            format!("{addr}::{mod_name}::{type_name}")
+        }
+        SignatureToken::DatatypeInstantiation(inst) => {
+            let (idx, type_args) = inst.as_ref();
+            let (addr, mod_name, type_name) = resolve_struct_name(module, idx);
+            let args: Vec<String> = type_args.iter().map(|t| format_token(module, t)).collect();
+            format!("{addr}::{mod_name}::{type_name}<{}>", args.join(", "))
+        }
+        SignatureToken::Reference(inner) => format!("&{}", format_token(module, inner)),
+        SignatureToken::MutableReference(inner) => format!("&mut {}", format_token(module, inner)),
+        SignatureToken::TypeParameter(idx) => format!("T{idx}"),
+    }
+}
+
+/// Classify a single SignatureToken into a ParamClass.
+fn classify_token(module: &CompiledModule, token: &SignatureToken) -> ParamClass {
+    match token {
+        // Primitives — all pure
+        SignatureToken::Bool => ParamClass::Pure {
+            pure_type: PureType::Bool,
+        },
+        SignatureToken::U8 => ParamClass::Pure {
+            pure_type: PureType::U8,
+        },
+        SignatureToken::U16 => ParamClass::Pure {
+            pure_type: PureType::U16,
+        },
+        SignatureToken::U32 => ParamClass::Pure {
+            pure_type: PureType::U32,
+        },
+        SignatureToken::U64 => ParamClass::Pure {
+            pure_type: PureType::U64,
+        },
+        SignatureToken::U128 => ParamClass::Pure {
+            pure_type: PureType::U128,
+        },
+        SignatureToken::U256 => ParamClass::Pure {
+            pure_type: PureType::U256,
+        },
+        SignatureToken::Address => ParamClass::Pure {
+            pure_type: PureType::Address,
+        },
+
+        // Vectors of pure types
+        SignatureToken::Vector(inner) => match inner.as_ref() {
+            SignatureToken::Bool => ParamClass::Pure {
+                pure_type: PureType::VectorBool,
+            },
+            SignatureToken::U8 => ParamClass::Pure {
+                pure_type: PureType::VectorU8,
+            },
+            SignatureToken::U16 => ParamClass::Pure {
+                pure_type: PureType::VectorU16,
+            },
+            SignatureToken::U32 => ParamClass::Pure {
+                pure_type: PureType::VectorU32,
+            },
+            SignatureToken::U64 => ParamClass::Pure {
+                pure_type: PureType::VectorU64,
+            },
+            SignatureToken::U128 => ParamClass::Pure {
+                pure_type: PureType::VectorU128,
+            },
+            SignatureToken::U256 => ParamClass::Pure {
+                pure_type: PureType::VectorU256,
+            },
+            SignatureToken::Address => ParamClass::Pure {
+                pure_type: PureType::VectorAddress,
+            },
+            _ => ParamClass::Unfuzzable {
+                reason: format!(
+                    "nested vector type: vector<{}>",
+                    format_token(module, inner)
+                ),
+            },
+        },
+
+        // Structs — check for well-known pure types
+        SignatureToken::Datatype(idx) => {
+            let (addr, mod_name, type_name) = resolve_struct_name(module, idx);
+            if is_string(&addr, &mod_name, &type_name) {
+                ParamClass::Pure {
+                    pure_type: PureType::String,
+                }
+            } else if is_ascii_string(&addr, &mod_name, &type_name) {
+                ParamClass::Pure {
+                    pure_type: PureType::AsciiString,
+                }
+            } else {
+                ParamClass::ObjectOwned {
+                    type_str: format!("{addr}::{mod_name}::{type_name}"),
+                }
+            }
+        }
+
+        // Generic structs — check for well-known pure types, otherwise object
+        SignatureToken::DatatypeInstantiation(inst) => {
+            let (idx, _type_args) = inst.as_ref();
+            let (addr, mod_name, type_name) = resolve_struct_name(module, idx);
+            ParamClass::ObjectOwned {
+                type_str: format!("{addr}::{mod_name}::{type_name}<...>"),
+            }
+        }
+
+        // References — check for system types (TxContext, Clock)
+        SignatureToken::Reference(inner) => classify_reference(module, inner, false),
+        SignatureToken::MutableReference(inner) => classify_reference(module, inner, true),
+
+        // Type parameters without concrete instantiation
+        SignatureToken::TypeParameter(idx) => ParamClass::Unfuzzable {
+            reason: format!("unresolved type parameter T{idx}"),
+        },
+
+        // Signer is not a normal parameter type
+        SignatureToken::Signer => ParamClass::Unfuzzable {
+            reason: "signer type".into(),
+        },
+    }
+}
+
+/// Classify a reference target (the inner type of &T or &mut T).
+fn classify_reference(
+    module: &CompiledModule,
+    inner: &SignatureToken,
+    mutable: bool,
+) -> ParamClass {
+    match inner {
+        SignatureToken::Datatype(idx) => {
+            let (addr, mod_name, type_name) = resolve_struct_name(module, idx);
+            if is_tx_context(&addr, &mod_name, &type_name) {
+                if mutable {
+                    ParamClass::SystemInjected {
+                        system_type: SystemType::MutTxContext,
+                    }
+                } else {
+                    ParamClass::SystemInjected {
+                        system_type: SystemType::TxContext,
+                    }
+                }
+            } else if is_clock(&addr, &mod_name, &type_name) {
+                ParamClass::SystemInjected {
+                    system_type: SystemType::Clock,
+                }
+            } else {
+                ParamClass::ObjectRef {
+                    mutable,
+                    type_str: format!("{addr}::{mod_name}::{type_name}"),
+                }
+            }
+        }
+        SignatureToken::DatatypeInstantiation(inst) => {
+            let (idx, _) = inst.as_ref();
+            let (addr, mod_name, type_name) = resolve_struct_name(module, idx);
+            ParamClass::ObjectRef {
+                mutable,
+                type_str: format!("{addr}::{mod_name}::{type_name}<...>"),
+            }
+        }
+        _ => ParamClass::Unfuzzable {
+            reason: format!(
+                "reference to non-struct type: {}{}",
+                if mutable { "&mut " } else { "&" },
+                format_token(module, inner)
+            ),
+        },
+    }
+}
+
+/// Classify all parameters of a function given its SignatureTokens and the compiled module.
+pub fn classify_params(
+    module: &CompiledModule,
+    param_tokens: &[SignatureToken],
+) -> ClassifiedFunction {
+    let params: Vec<(String, ParamClass)> = param_tokens
+        .iter()
+        .map(|token| {
+            let type_str = format_token(module, token);
+            let class = classify_token(module, token);
+            (type_str, class)
+        })
+        .collect();
+
+    let pure_count = params
+        .iter()
+        .filter(|(_, c)| matches!(c, ParamClass::Pure { .. }))
+        .count();
+    let system_count = params
+        .iter()
+        .filter(|(_, c)| matches!(c, ParamClass::SystemInjected { .. }))
+        .count();
+    let object_count = params
+        .iter()
+        .filter(|(_, c)| {
+            matches!(
+                c,
+                ParamClass::ObjectRef { .. } | ParamClass::ObjectOwned { .. }
+            )
+        })
+        .count();
+    let unfuzzable_count = params
+        .iter()
+        .filter(|(_, c)| matches!(c, ParamClass::Unfuzzable { .. }))
+        .count();
+    let is_fully_fuzzable = object_count == 0 && unfuzzable_count == 0;
+
+    ClassifiedFunction {
+        params,
+        is_fully_fuzzable,
+        pure_count,
+        system_count,
+        object_count,
+        unfuzzable_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pure_type_classification() {
+        // Verify that primitive tokens classify as Pure
+        // We can't easily construct a CompiledModule in tests, but we can test
+        // the classify_token logic for primitive types that don't need module context.
+        // The actual integration tests will use real modules.
+
+        // For primitives, classify_token doesn't use the module parameter,
+        // but the function signature requires it. We'll test the enum variants directly.
+        assert!(matches!(PureType::Bool, PureType::Bool));
+        assert!(matches!(PureType::U64, PureType::U64));
+    }
+
+    #[test]
+    fn test_classified_function_counts() {
+        let classified = ClassifiedFunction {
+            params: vec![
+                (
+                    "u64".into(),
+                    ParamClass::Pure {
+                        pure_type: PureType::U64,
+                    },
+                ),
+                (
+                    "bool".into(),
+                    ParamClass::Pure {
+                        pure_type: PureType::Bool,
+                    },
+                ),
+                (
+                    "&mut TxContext".into(),
+                    ParamClass::SystemInjected {
+                        system_type: SystemType::MutTxContext,
+                    },
+                ),
+            ],
+            is_fully_fuzzable: true,
+            pure_count: 2,
+            system_count: 1,
+            object_count: 0,
+            unfuzzable_count: 0,
+        };
+        assert!(classified.is_fully_fuzzable);
+        assert_eq!(classified.pure_count, 2);
+        assert_eq!(classified.system_count, 1);
+    }
+
+    #[test]
+    fn test_classified_function_with_objects() {
+        let classified = ClassifiedFunction {
+            params: vec![
+                (
+                    "&mut 0x2::coin::Coin<0x2::sui::SUI>".into(),
+                    ParamClass::ObjectRef {
+                        mutable: true,
+                        type_str: "0x2::coin::Coin<...>".into(),
+                    },
+                ),
+                (
+                    "u64".into(),
+                    ParamClass::Pure {
+                        pure_type: PureType::U64,
+                    },
+                ),
+            ],
+            is_fully_fuzzable: false,
+            pure_count: 1,
+            system_count: 0,
+            object_count: 1,
+            unfuzzable_count: 0,
+        };
+        assert!(!classified.is_fully_fuzzable);
+        assert_eq!(classified.object_count, 1);
+    }
+}

--- a/crates/sui-sandbox-core/src/fuzz/mod.rs
+++ b/crates/sui-sandbox-core/src/fuzz/mod.rs
@@ -1,0 +1,30 @@
+//! Move function fuzzing framework.
+//!
+//! Provides type-aware random input generation and execution loop for
+//! testing Move functions against the local VM with boundary-heavy
+//! value distributions.
+//!
+//! # Architecture
+//!
+//! - [`classifier`]: Classifies function parameters as pure (fuzzable),
+//!   system-injected, object-based, or unfuzzable
+//! - [`value_gen`]: Boundary-heavy random BCS value generation
+//! - [`runner`]: Fuzzing execution loop with gas profiling
+//! - [`report`]: Result types for fuzz outcomes
+//!
+//! # Phase 2 Seam
+//!
+//! The [`runner::FuzzRunner`] is designed to support future coverage-guided
+//! fuzzing via an optional `CoverageTracker` parameter (not yet implemented).
+
+pub mod classifier;
+pub mod report;
+pub mod runner;
+pub mod value_gen;
+
+pub use classifier::{classify_params, ClassifiedFunction, ParamClass, PureType, SystemType};
+pub use report::{
+    AbortInfo, ErrorInfo, FuzzOutcomeSummary, FuzzReport, GasProfile, InterestingCase, Outcome,
+};
+pub use runner::{FuzzConfig, FuzzRunner};
+pub use value_gen::ValueGenerator;

--- a/crates/sui-sandbox-core/src/fuzz/report.rs
+++ b/crates/sui-sandbox-core/src/fuzz/report.rs
@@ -1,0 +1,165 @@
+//! Report types for fuzz testing results.
+
+use serde::{Deserialize, Serialize};
+
+use super::classifier::ClassifiedFunction;
+
+/// Complete report from a fuzz run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FuzzReport {
+    /// Target function (e.g., "0x2::math::sqrt_u128").
+    pub target: String,
+    /// Total iterations requested.
+    pub total_iterations: u64,
+    /// Iterations actually completed (may be less if fail_fast triggered).
+    pub completed_iterations: u64,
+    /// Random seed used.
+    pub seed: u64,
+    /// Elapsed time in milliseconds.
+    pub elapsed_ms: u64,
+    /// Parameter classification.
+    pub classification: ClassifiedFunction,
+    /// Outcome summary.
+    pub outcomes: FuzzOutcomeSummary,
+    /// Gas usage profile.
+    pub gas_profile: GasProfile,
+    /// Interesting cases (first occurrence of each distinct abort/error).
+    pub interesting_cases: Vec<InterestingCase>,
+}
+
+/// Summary of fuzz outcomes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FuzzOutcomeSummary {
+    /// Number of successful executions.
+    pub successes: u64,
+    /// Number of gas exhaustion events.
+    pub gas_exhaustions: u64,
+    /// Abort info grouped by abort code.
+    pub aborts: Vec<AbortInfo>,
+    /// Error info grouped by error message.
+    pub errors: Vec<ErrorInfo>,
+}
+
+/// Information about a specific abort code.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AbortInfo {
+    /// The abort code.
+    pub code: u64,
+    /// Module location where the abort occurred (if available).
+    pub location: Option<String>,
+    /// Number of times this abort was triggered.
+    pub count: u64,
+    /// Human-readable representation of the first input that triggered this abort.
+    pub sample_inputs: Vec<String>,
+    /// BCS-encoded inputs (hex) for reproducibility.
+    pub sample_inputs_bcs: Vec<String>,
+}
+
+/// Information about a specific error type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorInfo {
+    /// Error message (may be truncated for grouping).
+    pub message: String,
+    /// Number of times this error occurred.
+    pub count: u64,
+}
+
+/// Gas usage profile across all iterations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GasProfile {
+    pub min: u64,
+    pub max: u64,
+    pub avg: u64,
+    pub p50: u64,
+    pub p99: u64,
+    /// The input that used the most gas (human-readable).
+    pub max_input: Vec<String>,
+}
+
+impl GasProfile {
+    /// Compute gas profile from a list of gas values.
+    pub fn from_values(gas_values: &mut [u64], max_input: Vec<String>) -> Self {
+        if gas_values.is_empty() {
+            return Self {
+                min: 0,
+                max: 0,
+                avg: 0,
+                p50: 0,
+                p99: 0,
+                max_input,
+            };
+        }
+
+        gas_values.sort_unstable();
+        let len = gas_values.len();
+        let sum: u64 = gas_values.iter().sum();
+
+        Self {
+            min: gas_values[0],
+            max: gas_values[len - 1],
+            avg: sum / len as u64,
+            p50: gas_values[len / 2],
+            p99: gas_values[(len as f64 * 0.99) as usize],
+            max_input,
+        }
+    }
+}
+
+/// A single interesting case discovered during fuzzing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InterestingCase {
+    /// Which iteration this occurred on.
+    pub iteration: u64,
+    /// The outcome.
+    pub outcome: Outcome,
+    /// Human-readable inputs.
+    pub inputs_human: Vec<String>,
+    /// BCS-encoded inputs (hex) for reproducibility.
+    pub inputs_bcs_hex: Vec<String>,
+    /// Gas used for this execution.
+    pub gas_used: u64,
+}
+
+/// Outcome of a single fuzz execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Outcome {
+    Success,
+    Abort { code: u64, location: Option<String> },
+    Error { message: String },
+    GasExhaustion,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gas_profile_from_values() {
+        let mut values = vec![100, 200, 300, 400, 500];
+        let profile = GasProfile::from_values(&mut values, vec!["test".into()]);
+        assert_eq!(profile.min, 100);
+        assert_eq!(profile.max, 500);
+        assert_eq!(profile.avg, 300);
+        assert_eq!(profile.p50, 300);
+    }
+
+    #[test]
+    fn test_gas_profile_empty() {
+        let mut values = vec![];
+        let profile = GasProfile::from_values(&mut values, vec![]);
+        assert_eq!(profile.min, 0);
+        assert_eq!(profile.max, 0);
+    }
+
+    #[test]
+    fn test_outcome_serialization() {
+        let outcome = Outcome::Abort {
+            code: 42,
+            location: Some("0x2::math::sqrt".into()),
+        };
+        let json = serde_json::to_string(&outcome).unwrap();
+        assert!(json.contains("\"type\":\"Abort\""));
+        assert!(json.contains("\"code\":42"));
+    }
+}

--- a/crates/sui-sandbox-core/src/fuzz/runner.rs
+++ b/crates/sui-sandbox-core/src/fuzz/runner.rs
@@ -1,0 +1,403 @@
+//! Fuzzing execution loop.
+//!
+//! Runs N iterations of random input generation + VM execution,
+//! collecting outcomes and gas statistics.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use anyhow::{anyhow, Result};
+use move_core_types::account_address::AccountAddress;
+use move_core_types::identifier::Identifier;
+use move_core_types::language_storage::TypeTag;
+
+use crate::ptb::{Argument, Command, InputValue, PTBExecutor};
+use crate::resolver::LocalModuleResolver;
+use crate::vm::{SimulationConfig, VMHarness};
+
+use super::classifier::{ClassifiedFunction, ParamClass, PureType};
+use super::report::*;
+use super::value_gen::ValueGenerator;
+
+/// Configuration for a fuzz run.
+pub struct FuzzConfig {
+    /// Number of iterations to run.
+    pub iterations: u64,
+    /// Random seed for reproducibility.
+    pub seed: u64,
+    /// Sender address for transactions.
+    pub sender: AccountAddress,
+    /// Gas budget per execution.
+    pub gas_budget: u64,
+    /// Type arguments for generic functions.
+    pub type_args: Vec<TypeTag>,
+    /// Stop on first abort/error.
+    pub fail_fast: bool,
+    /// Maximum vector length for generated inputs.
+    pub max_vector_len: usize,
+}
+
+/// Runs fuzz iterations against the local Move VM.
+pub struct FuzzRunner<'a> {
+    resolver: &'a LocalModuleResolver,
+}
+
+impl<'a> FuzzRunner<'a> {
+    pub fn new(resolver: &'a LocalModuleResolver) -> Self {
+        Self { resolver }
+    }
+
+    /// Run the fuzzer against a target function.
+    ///
+    /// Returns a complete FuzzReport with outcomes, gas profile, and interesting cases.
+    pub fn run(
+        &self,
+        package: AccountAddress,
+        module_name: &str,
+        function_name: &str,
+        classification: &ClassifiedFunction,
+        config: &FuzzConfig,
+    ) -> Result<FuzzReport> {
+        let target = format!(
+            "{}::{}::{}",
+            package.to_hex_literal(),
+            module_name,
+            function_name
+        );
+
+        // Collect the pure parameter types (in order), skipping system-injected ones
+        let pure_params: Vec<(usize, &PureType)> = classification
+            .params
+            .iter()
+            .enumerate()
+            .filter_map(|(i, (_, class))| {
+                if let ParamClass::Pure { pure_type } = class {
+                    Some((i, pure_type))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let mut gen = ValueGenerator::new(config.seed, config.max_vector_len);
+        let mut successes = 0u64;
+        let mut gas_exhaustions = 0u64;
+        let mut abort_map: HashMap<u64, AbortInfo> = HashMap::new();
+        let mut error_map: HashMap<String, u64> = HashMap::new();
+        let mut gas_values: Vec<u64> = Vec::with_capacity(config.iterations as usize);
+        let mut max_gas_input: Vec<String> = Vec::new();
+        let mut max_gas_value = 0u64;
+        let mut interesting_cases: Vec<InterestingCase> = Vec::new();
+        let mut completed = 0u64;
+
+        let module_ident = Identifier::new(module_name)
+            .map_err(|e| anyhow!("Invalid module name '{}': {}", module_name, e))?;
+        let function_ident = Identifier::new(function_name)
+            .map_err(|e| anyhow!("Invalid function name '{}': {}", function_name, e))?;
+
+        let start = Instant::now();
+
+        for iteration in 0..config.iterations {
+            // Generate random pure inputs
+            let mut input_values: Vec<InputValue> = Vec::new();
+            let mut input_human: Vec<String> = Vec::new();
+            let mut input_bcs_hex: Vec<String> = Vec::new();
+
+            for (_param_idx, pure_type) in &pure_params {
+                let bcs_bytes = gen.generate(pure_type);
+                input_human.push(ValueGenerator::format_value(pure_type, &bcs_bytes));
+                input_bcs_hex.push(hex::encode(&bcs_bytes));
+                input_values.push(InputValue::Pure(bcs_bytes));
+            }
+
+            // Create fresh VM harness per iteration
+            let sim_config = SimulationConfig {
+                sender_address: config.sender.into(),
+                gas_budget: Some(config.gas_budget),
+                deterministic_random: true,
+                mock_crypto_pass: true,
+                ..Default::default()
+            };
+            let mut harness = match VMHarness::with_config(self.resolver, false, sim_config) {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(anyhow!("Failed to create VM harness: {}", e));
+                }
+            };
+
+            // Create executor and add inputs
+            let mut executor = PTBExecutor::new(&mut harness);
+            for input in &input_values {
+                executor.add_input(input.clone());
+            }
+
+            // Build MoveCall command
+            let args: Vec<Argument> = (0..input_values.len())
+                .map(|i| Argument::Input(i as u16))
+                .collect();
+            let command = Command::MoveCall {
+                package,
+                module: module_ident.clone(),
+                function: function_ident.clone(),
+                type_args: config.type_args.clone(),
+                args,
+            };
+
+            // Execute
+            let effects = executor.execute_commands(&[command]);
+
+            // Classify outcome
+            let (outcome, gas_used) = match effects {
+                Ok(effects) => {
+                    let gas = effects.gas_used;
+                    if effects.success {
+                        (Outcome::Success, gas)
+                    } else {
+                        let err_msg = effects.error.unwrap_or_default();
+                        classify_error(&err_msg, gas)
+                    }
+                }
+                Err(e) => {
+                    let err_msg = e.to_string();
+                    classify_error(&err_msg, 0)
+                }
+            };
+
+            // Track gas
+            gas_values.push(gas_used);
+            if gas_used > max_gas_value {
+                max_gas_value = gas_used;
+                max_gas_input = input_human.clone();
+            }
+
+            // Update counters
+            match &outcome {
+                Outcome::Success => {
+                    successes += 1;
+                }
+                Outcome::Abort { code, location } => {
+                    let entry = abort_map.entry(*code).or_insert_with(|| AbortInfo {
+                        code: *code,
+                        location: location.clone(),
+                        count: 0,
+                        sample_inputs: input_human.clone(),
+                        sample_inputs_bcs: input_bcs_hex.clone(),
+                    });
+                    entry.count += 1;
+
+                    // Record as interesting (first occurrence of this abort code)
+                    if entry.count == 1 {
+                        interesting_cases.push(InterestingCase {
+                            iteration,
+                            outcome: outcome.clone(),
+                            inputs_human: input_human.clone(),
+                            inputs_bcs_hex: input_bcs_hex.clone(),
+                            gas_used,
+                        });
+                    }
+                }
+                Outcome::Error { message } => {
+                    let key = truncate_error(message);
+                    let count = error_map.entry(key.clone()).or_insert(0);
+                    *count += 1;
+
+                    // Record first occurrence
+                    if *count == 1 {
+                        interesting_cases.push(InterestingCase {
+                            iteration,
+                            outcome: outcome.clone(),
+                            inputs_human: input_human.clone(),
+                            inputs_bcs_hex: input_bcs_hex.clone(),
+                            gas_used,
+                        });
+                    }
+                }
+                Outcome::GasExhaustion => {
+                    gas_exhaustions += 1;
+                    if gas_exhaustions == 1 {
+                        interesting_cases.push(InterestingCase {
+                            iteration,
+                            outcome: outcome.clone(),
+                            inputs_human: input_human.clone(),
+                            inputs_bcs_hex: input_bcs_hex.clone(),
+                            gas_used,
+                        });
+                    }
+                }
+            }
+
+            completed = iteration + 1;
+
+            // Fail-fast check
+            if config.fail_fast && !matches!(outcome, Outcome::Success) {
+                break;
+            }
+        }
+
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+
+        // Build abort list sorted by code
+        let mut aborts: Vec<AbortInfo> = abort_map.into_values().collect();
+        aborts.sort_by_key(|a| a.code);
+
+        // Build error list sorted by count (descending)
+        let mut errors: Vec<ErrorInfo> = error_map
+            .into_iter()
+            .map(|(message, count)| ErrorInfo { message, count })
+            .collect();
+        errors.sort_by(|a, b| b.count.cmp(&a.count));
+
+        let gas_profile = GasProfile::from_values(&mut gas_values, max_gas_input);
+
+        Ok(FuzzReport {
+            target,
+            total_iterations: config.iterations,
+            completed_iterations: completed,
+            seed: config.seed,
+            elapsed_ms,
+            classification: classification.clone(),
+            outcomes: FuzzOutcomeSummary {
+                successes,
+                gas_exhaustions,
+                aborts,
+                errors,
+            },
+            gas_profile,
+            interesting_cases,
+        })
+    }
+}
+
+/// Parse an error message to extract abort code and location.
+fn classify_error(err_msg: &str, gas: u64) -> (Outcome, u64) {
+    // Check for gas exhaustion
+    if err_msg.contains("OutOfGas")
+        || err_msg.contains("out of gas")
+        || err_msg.contains("OUT_OF_GAS")
+    {
+        return (Outcome::GasExhaustion, gas);
+    }
+
+    // Try to extract abort code
+    // Common patterns: "ABORTED with code 42", "Move abort: 42", "abort(42)"
+    if let Some(code) = extract_abort_code(err_msg) {
+        let location = extract_abort_location(err_msg);
+        return (Outcome::Abort { code, location }, gas);
+    }
+
+    (
+        Outcome::Error {
+            message: err_msg.to_string(),
+        },
+        gas,
+    )
+}
+
+/// Extract abort code from an error message.
+fn extract_abort_code(msg: &str) -> Option<u64> {
+    // Pattern: "with code N" or "abort code N"
+    for pattern in &["with code ", "abort code ", "abort(", "ABORTED("] {
+        if let Some(pos) = msg.find(pattern) {
+            let after = &msg[pos + pattern.len()..];
+            let num_str: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if let Ok(code) = num_str.parse::<u64>() {
+                return Some(code);
+            }
+        }
+    }
+
+    // Pattern: "MoveAbort(..., N)" — common in Sui VM errors
+    if let Some(pos) = msg.find("MoveAbort") {
+        // Find the last number before the closing paren
+        if let Some(paren_end) = msg[pos..].find(')') {
+            let inside = &msg[pos..pos + paren_end];
+            // Split by comma, take last part
+            if let Some(last) = inside.rsplit(',').next() {
+                let num_str: String = last.trim().chars().filter(|c| c.is_ascii_digit()).collect();
+                if let Ok(code) = num_str.parse::<u64>() {
+                    return Some(code);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Extract the abort location (module path) from an error message.
+fn extract_abort_location(msg: &str) -> Option<String> {
+    // Pattern: "in module 0x...::name::func" or similar
+    // Look for "0x" followed by "::module::function" pattern
+    if let Some(pos) = msg.find("0x") {
+        let after = &msg[pos..];
+        // Take characters that look like a module path
+        let path: String = after
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == ':' || *c == '_' || *c == 'x')
+            .collect();
+        if path.contains("::") {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Truncate an error message for grouping (first 200 chars).
+fn truncate_error(msg: &str) -> String {
+    if msg.len() > 200 {
+        format!("{}...", &msg[..200])
+    } else {
+        msg.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_abort_code_with_code() {
+        assert_eq!(extract_abort_code("ABORTED with code 42"), Some(42));
+    }
+
+    #[test]
+    fn test_extract_abort_code_move_abort() {
+        assert_eq!(
+            extract_abort_code("MoveAbort(0x1::vector, 1) in command 0"),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn test_extract_abort_code_none() {
+        assert_eq!(extract_abort_code("some random error"), None);
+    }
+
+    #[test]
+    fn test_classify_error_gas() {
+        let (outcome, _) = classify_error("OutOfGas in function call", 0);
+        assert!(matches!(outcome, Outcome::GasExhaustion));
+    }
+
+    #[test]
+    fn test_classify_error_abort() {
+        let (outcome, _) = classify_error("ABORTED with code 5 in 0x2::math", 100);
+        match outcome {
+            Outcome::Abort { code, .. } => assert_eq!(code, 5),
+            _ => panic!("Expected Abort"),
+        }
+    }
+
+    #[test]
+    fn test_truncate_error_short() {
+        assert_eq!(truncate_error("short error"), "short error");
+    }
+
+    #[test]
+    fn test_truncate_error_long() {
+        let long = "x".repeat(300);
+        let truncated = truncate_error(&long);
+        assert!(truncated.ends_with("..."));
+        assert_eq!(truncated.len(), 203);
+    }
+}

--- a/crates/sui-sandbox-core/src/fuzz/value_gen.rs
+++ b/crates/sui-sandbox-core/src/fuzz/value_gen.rs
@@ -1,0 +1,458 @@
+//! Boundary-heavy random value generation for Move function fuzzing.
+//!
+//! Generates BCS-encoded values for each [`PureType`], with an aggressive
+//! boundary distribution: ~40% exact boundaries, ~30% near-boundary, ~30% uniform.
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+use super::classifier::PureType;
+
+/// Random value generator with boundary-heavy distribution.
+pub struct ValueGenerator {
+    rng: StdRng,
+    max_vector_len: usize,
+}
+
+impl ValueGenerator {
+    /// Create a new generator with the given seed and max vector length.
+    pub fn new(seed: u64, max_vector_len: usize) -> Self {
+        Self {
+            rng: StdRng::seed_from_u64(seed),
+            max_vector_len,
+        }
+    }
+
+    /// Generate a random BCS-encoded value for the given pure type.
+    pub fn generate(&mut self, ty: &PureType) -> Vec<u8> {
+        match ty {
+            PureType::Bool => self.gen_bool(),
+            PureType::U8 => self.gen_u8(),
+            PureType::U16 => self.gen_u16(),
+            PureType::U32 => self.gen_u32(),
+            PureType::U64 => self.gen_u64(),
+            PureType::U128 => self.gen_u128(),
+            PureType::U256 => self.gen_u256(),
+            PureType::Address => self.gen_address(),
+            PureType::VectorBool => self.gen_vector(PureType::Bool),
+            PureType::VectorU8 => self.gen_vector(PureType::U8),
+            PureType::VectorU16 => self.gen_vector(PureType::U16),
+            PureType::VectorU32 => self.gen_vector(PureType::U32),
+            PureType::VectorU64 => self.gen_vector(PureType::U64),
+            PureType::VectorU128 => self.gen_vector(PureType::U128),
+            PureType::VectorU256 => self.gen_vector(PureType::U256),
+            PureType::VectorAddress => self.gen_vector(PureType::Address),
+            PureType::String => self.gen_string(),
+            PureType::AsciiString => self.gen_ascii_string(),
+        }
+    }
+
+    /// Format a BCS-encoded value as a human-readable string for reporting.
+    pub fn format_value(ty: &PureType, bcs_bytes: &[u8]) -> String {
+        match ty {
+            PureType::Bool => bcs::from_bytes::<bool>(bcs_bytes)
+                .map(|v| v.to_string())
+                .unwrap_or_else(|_| hex::encode(bcs_bytes)),
+            PureType::U8 => bcs::from_bytes::<u8>(bcs_bytes)
+                .map(|v| format!("u8:{v}"))
+                .unwrap_or_else(|_| hex::encode(bcs_bytes)),
+            PureType::U16 => bcs::from_bytes::<u16>(bcs_bytes)
+                .map(|v| format!("u16:{v}"))
+                .unwrap_or_else(|_| hex::encode(bcs_bytes)),
+            PureType::U32 => bcs::from_bytes::<u32>(bcs_bytes)
+                .map(|v| format!("u32:{v}"))
+                .unwrap_or_else(|_| hex::encode(bcs_bytes)),
+            PureType::U64 => bcs::from_bytes::<u64>(bcs_bytes)
+                .map(|v| v.to_string())
+                .unwrap_or_else(|_| hex::encode(bcs_bytes)),
+            PureType::U128 => bcs::from_bytes::<u128>(bcs_bytes)
+                .map(|v| format!("u128:{v}"))
+                .unwrap_or_else(|_| hex::encode(bcs_bytes)),
+            PureType::U256 => format!("u256:0x{}", hex::encode(bcs_bytes)),
+            PureType::Address => format!("0x{}", hex::encode(bcs_bytes)),
+            PureType::String | PureType::AsciiString => bcs::from_bytes::<Vec<u8>>(bcs_bytes)
+                .map(|v| {
+                    std::string::String::from_utf8(v)
+                        .unwrap_or_else(|e| format!("bytes:{}", hex::encode(e.as_bytes())))
+                })
+                .unwrap_or_else(|_| hex::encode(bcs_bytes)),
+            PureType::VectorBool
+            | PureType::VectorU8
+            | PureType::VectorU16
+            | PureType::VectorU32
+            | PureType::VectorU64
+            | PureType::VectorU128
+            | PureType::VectorU256
+            | PureType::VectorAddress => format!("vector:0x{}", hex::encode(bcs_bytes)),
+        }
+    }
+
+    // ---- Primitive generators ----
+
+    fn gen_bool(&mut self) -> Vec<u8> {
+        bcs::to_bytes(&self.rng.gen_bool(0.5)).unwrap()
+    }
+
+    fn gen_u8(&mut self) -> Vec<u8> {
+        let val = self.gen_integer_u64(&U8_BOUNDARIES, u8::MAX as u64) as u8;
+        bcs::to_bytes(&val).unwrap()
+    }
+
+    fn gen_u16(&mut self) -> Vec<u8> {
+        let val = self.gen_integer_u64(&U16_BOUNDARIES, u16::MAX as u64) as u16;
+        bcs::to_bytes(&val).unwrap()
+    }
+
+    fn gen_u32(&mut self) -> Vec<u8> {
+        let val = self.gen_integer_u64(&U32_BOUNDARIES, u32::MAX as u64) as u32;
+        bcs::to_bytes(&val).unwrap()
+    }
+
+    fn gen_u64(&mut self) -> Vec<u8> {
+        let val = self.gen_integer_u64(&U64_BOUNDARIES, u64::MAX);
+        bcs::to_bytes(&val).unwrap()
+    }
+
+    fn gen_u128(&mut self) -> Vec<u8> {
+        let val = self.gen_integer_u128(&U128_BOUNDARIES, u128::MAX);
+        bcs::to_bytes(&val).unwrap()
+    }
+
+    fn gen_u256(&mut self) -> Vec<u8> {
+        // U256 is 32 bytes in BCS, little-endian
+        let tier: f64 = self.rng.gen();
+        if tier < 0.4 {
+            // Boundary: all zeros, all ones, or power-of-2 patterns
+            let choice = self.rng.gen_range(0..4);
+            match choice {
+                0 => vec![0u8; 32], // 0
+                1 => {
+                    // 1
+                    let mut bytes = vec![0u8; 32];
+                    bytes[0] = 1;
+                    bytes
+                }
+                2 => vec![0xFF; 32], // MAX
+                _ => {
+                    // Random power of 2
+                    let mut bytes = vec![0u8; 32];
+                    let byte_idx = self.rng.gen_range(0..32);
+                    let bit_idx = self.rng.gen_range(0..8);
+                    bytes[byte_idx] = 1 << bit_idx;
+                    bytes
+                }
+            }
+        } else {
+            // Uniform random 32 bytes
+            let mut bytes = vec![0u8; 32];
+            self.rng.fill(&mut bytes[..]);
+            bytes
+        }
+    }
+
+    fn gen_address(&mut self) -> Vec<u8> {
+        let tier: f64 = self.rng.gen();
+        if tier < 0.3 {
+            // Well-known addresses
+            let choice = self.rng.gen_range(0..5);
+            let mut addr = [0u8; 32];
+            match choice {
+                0 => {}               // 0x0
+                1 => addr[31] = 1,    // 0x1
+                2 => addr[31] = 2,    // 0x2
+                3 => addr[31] = 3,    // 0x3
+                _ => addr[31] = 0xEE, // sender-like
+            }
+            addr.to_vec()
+        } else {
+            // Random 32 bytes
+            let mut addr = [0u8; 32];
+            self.rng.fill(&mut addr[..]);
+            addr.to_vec()
+        }
+    }
+
+    fn gen_string(&mut self) -> Vec<u8> {
+        let len = self.gen_vector_len();
+        let s: String = (0..len)
+            .map(|_| self.rng.gen_range(0x20..=0x7E) as u8 as char)
+            .collect();
+        bcs::to_bytes(&s.into_bytes()).unwrap()
+    }
+
+    fn gen_ascii_string(&mut self) -> Vec<u8> {
+        let len = self.gen_vector_len();
+        let bytes: Vec<u8> = (0..len).map(|_| self.rng.gen_range(0x20..=0x7E)).collect();
+        bcs::to_bytes(&bytes).unwrap()
+    }
+
+    // ---- Vector generator ----
+
+    fn gen_vector(&mut self, element_type: PureType) -> Vec<u8> {
+        let len = self.gen_vector_len();
+        // BCS vector: ULEB128 length prefix + concatenated element bytes
+        let elements: Vec<Vec<u8>> = (0..len).map(|_| self.generate(&element_type)).collect();
+        // Use BCS encoding: length as ULEB128 + raw element bytes
+        let mut result = Vec::new();
+        // ULEB128 encode the length
+        let mut val = len;
+        loop {
+            let mut byte = (val & 0x7F) as u8;
+            val >>= 7;
+            if val != 0 {
+                byte |= 0x80;
+            }
+            result.push(byte);
+            if val == 0 {
+                break;
+            }
+        }
+        for elem in &elements {
+            result.extend_from_slice(elem);
+        }
+        result
+    }
+
+    /// Generate a vector length with edge-case weighting.
+    fn gen_vector_len(&mut self) -> usize {
+        let tier: f64 = self.rng.gen();
+        if tier < 0.20 {
+            0 // empty
+        } else if tier < 0.35 {
+            1 // single element
+        } else if tier < 0.50 {
+            self.max_vector_len // max length
+        } else {
+            self.rng.gen_range(2..=self.max_vector_len)
+        }
+    }
+
+    // ---- Integer generation with tiered distribution ----
+
+    /// Generate a u64 value with boundary-heavy distribution.
+    fn gen_integer_u64(&mut self, boundaries: &[u64], max: u64) -> u64 {
+        let tier: f64 = self.rng.gen();
+        if tier < 0.4 {
+            // Exact boundary value
+            boundaries[self.rng.gen_range(0..boundaries.len())]
+        } else if tier < 0.7 {
+            // Near-boundary: pick a boundary, offset by ±1..16
+            let base = boundaries[self.rng.gen_range(0..boundaries.len())];
+            let offset = self.rng.gen_range(1..=16_i64);
+            if self.rng.gen_bool(0.5) {
+                base.saturating_add(offset as u64).min(max)
+            } else {
+                base.saturating_sub(offset as u64)
+            }
+        } else {
+            // Uniform random
+            self.rng.gen_range(0..=max)
+        }
+    }
+
+    /// Generate a u128 value with boundary-heavy distribution.
+    fn gen_integer_u128(&mut self, boundaries: &[u128], max: u128) -> u128 {
+        let tier: f64 = self.rng.gen();
+        if tier < 0.4 {
+            boundaries[self.rng.gen_range(0..boundaries.len())]
+        } else if tier < 0.7 {
+            let base = boundaries[self.rng.gen_range(0..boundaries.len())];
+            let offset = self.rng.gen_range(1..=16_u128);
+            if self.rng.gen_bool(0.5) {
+                base.saturating_add(offset).min(max)
+            } else {
+                base.saturating_sub(offset)
+            }
+        } else {
+            // For uniform u128, generate two u64s
+            let hi = self.rng.gen::<u64>() as u128;
+            let lo = self.rng.gen::<u64>() as u128;
+            (hi << 64) | lo
+        }
+    }
+}
+
+// ---- Boundary value tables ----
+
+const U8_BOUNDARIES: [u64; 7] = [0, 1, 2, 127, 128, 254, 255];
+
+const U16_BOUNDARIES: [u64; 9] = [0, 1, 2, 255, 256, 32767, 32768, 65534, 65535];
+
+const U32_BOUNDARIES: [u64; 11] = [
+    0,
+    1,
+    2,
+    255,
+    256,
+    65535,
+    65536,
+    2_147_483_647, // 2^31 - 1
+    2_147_483_648, // 2^31
+    4_294_967_294, // 2^32 - 2
+    4_294_967_295, // 2^32 - 1
+];
+
+const U64_BOUNDARIES: [u64; 15] = [
+    0,
+    1,
+    2,
+    255,
+    256,
+    65535,
+    65536,
+    2_147_483_647,
+    2_147_483_648,
+    4_294_967_295,
+    4_294_967_296,
+    9_223_372_036_854_775_807,  // 2^63 - 1
+    9_223_372_036_854_775_808,  // 2^63
+    18_446_744_073_709_551_614, // 2^64 - 2
+    18_446_744_073_709_551_615, // 2^64 - 1
+];
+
+const U128_BOUNDARIES: [u128; 19] = [
+    0,
+    1,
+    2,
+    255,
+    256,
+    65535,
+    65536,
+    u32::MAX as u128,
+    (u32::MAX as u128) + 1,
+    u64::MAX as u128,
+    (u64::MAX as u128) + 1,
+    i64::MAX as u128,
+    (i64::MAX as u128) + 1,
+    170_141_183_460_469_231_731_687_303_715_884_105_727, // 2^127 - 1
+    170_141_183_460_469_231_731_687_303_715_884_105_728, // 2^127
+    340_282_366_920_938_463_463_374_607_431_768_211_453, // 2^128 - 3
+    340_282_366_920_938_463_463_374_607_431_768_211_454, // 2^128 - 2
+    340_282_366_920_938_463_463_374_607_431_768_211_455, // 2^128 - 1 (MAX)
+    0, // duplicate 0 for array size alignment — filtered by random selection
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deterministic_seed() {
+        let mut gen1 = ValueGenerator::new(42, 32);
+        let mut gen2 = ValueGenerator::new(42, 32);
+
+        for ty in &[
+            PureType::Bool,
+            PureType::U8,
+            PureType::U64,
+            PureType::Address,
+        ] {
+            let v1 = gen1.generate(ty);
+            let v2 = gen2.generate(ty);
+            assert_eq!(v1, v2, "Same seed should produce same value for {:?}", ty);
+        }
+    }
+
+    #[test]
+    fn test_u8_bcs_roundtrip() {
+        let mut gen = ValueGenerator::new(123, 32);
+        for _ in 0..100 {
+            let bytes = gen.generate(&PureType::U8);
+            let val: u8 = bcs::from_bytes(&bytes).expect("u8 BCS roundtrip");
+            assert!(val <= u8::MAX);
+        }
+    }
+
+    #[test]
+    fn test_u64_bcs_roundtrip() {
+        let mut gen = ValueGenerator::new(456, 32);
+        for _ in 0..100 {
+            let bytes = gen.generate(&PureType::U64);
+            let _val: u64 = bcs::from_bytes(&bytes).expect("u64 BCS roundtrip");
+        }
+    }
+
+    #[test]
+    fn test_u128_bcs_roundtrip() {
+        let mut gen = ValueGenerator::new(789, 32);
+        for _ in 0..100 {
+            let bytes = gen.generate(&PureType::U128);
+            let _val: u128 = bcs::from_bytes(&bytes).expect("u128 BCS roundtrip");
+        }
+    }
+
+    #[test]
+    fn test_bool_bcs_roundtrip() {
+        let mut gen = ValueGenerator::new(101, 32);
+        for _ in 0..100 {
+            let bytes = gen.generate(&PureType::Bool);
+            let _val: bool = bcs::from_bytes(&bytes).expect("bool BCS roundtrip");
+        }
+    }
+
+    #[test]
+    fn test_address_is_32_bytes() {
+        let mut gen = ValueGenerator::new(202, 32);
+        for _ in 0..100 {
+            let bytes = gen.generate(&PureType::Address);
+            assert_eq!(bytes.len(), 32, "Address should always be 32 bytes");
+        }
+    }
+
+    #[test]
+    fn test_vector_u8_bcs_roundtrip() {
+        let mut gen = ValueGenerator::new(303, 16);
+        for _ in 0..50 {
+            let bytes = gen.generate(&PureType::VectorU8);
+            let _val: Vec<u8> = bcs::from_bytes(&bytes).expect("vector<u8> BCS roundtrip");
+        }
+    }
+
+    #[test]
+    fn test_string_bcs_roundtrip() {
+        let mut gen = ValueGenerator::new(404, 32);
+        for _ in 0..50 {
+            let bytes = gen.generate(&PureType::String);
+            let val: Vec<u8> = bcs::from_bytes(&bytes).expect("String BCS roundtrip");
+            // All bytes should be printable ASCII
+            for b in &val {
+                assert!(
+                    (0x20..=0x7E).contains(b),
+                    "String byte {:#x} not in printable ASCII range",
+                    b
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_boundaries_appear_in_u8() {
+        let mut gen = ValueGenerator::new(505, 32);
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..1000 {
+            let bytes = gen.generate(&PureType::U8);
+            let val: u8 = bcs::from_bytes(&bytes).unwrap();
+            seen.insert(val);
+        }
+        // With 1000 iterations and 40% boundary rate, we should see the key boundaries
+        assert!(seen.contains(&0), "Should see boundary 0");
+        assert!(seen.contains(&255), "Should see boundary 255");
+        assert!(seen.contains(&1), "Should see boundary 1");
+    }
+
+    #[test]
+    fn test_format_value() {
+        assert_eq!(
+            ValueGenerator::format_value(&PureType::Bool, &bcs::to_bytes(&true).unwrap()),
+            "true"
+        );
+        assert_eq!(
+            ValueGenerator::format_value(&PureType::U8, &bcs::to_bytes(&42u8).unwrap()),
+            "u8:42"
+        );
+        assert_eq!(
+            ValueGenerator::format_value(&PureType::U64, &bcs::to_bytes(&1000u64).unwrap()),
+            "1000"
+        );
+    }
+}

--- a/crates/sui-sandbox-core/src/lib.rs
+++ b/crates/sui-sandbox-core/src/lib.rs
@@ -78,6 +78,9 @@ pub mod package_builder;
 pub mod state_layer;
 pub mod storage_log;
 
+// Move function fuzzing
+pub mod fuzz;
+
 // Utilities for working around infrastructure limitations
 pub mod utilities;
 

--- a/crates/sui-sandbox-core/src/resolver.rs
+++ b/crates/sui-sandbox-core/src/resolver.rs
@@ -1341,9 +1341,11 @@ impl LocalModuleResolver {
                 );
                 let is_entry = def.is_entry;
 
+                let params_sig = &module.signatures[handle.parameters.0 as usize];
                 let info = CachedFunctionInfo {
                     signature: FunctionSignature {
                         type_param_count: handle.type_parameters.len(),
+                        parameter_types: params_sig.0.clone(),
                         return_types: return_sig.0.clone(),
                     },
                     is_callable: is_public || is_entry,
@@ -2218,6 +2220,8 @@ pub fn signature_token_to_type_tag(
 pub struct FunctionSignature {
     /// Number of type parameters the function expects
     pub type_param_count: usize,
+    /// Parameter types as SignatureTokens
+    pub parameter_types: Vec<move_binary_format::file_format::SignatureToken>,
     /// Return types as SignatureTokens (need type_args to fully resolve)
     pub return_types: Vec<move_binary_format::file_format::SignatureToken>,
 }

--- a/src/bin/sandbox_cli/mod.rs
+++ b/src/bin/sandbox_cli/mod.rs
@@ -14,6 +14,7 @@ pub mod replay;
 pub mod run;
 pub mod snapshot;
 pub mod state;
+pub mod test;
 pub mod tools;
 pub mod view;
 

--- a/src/bin/sandbox_cli/test/fuzz.rs
+++ b/src/bin/sandbox_cli/test/fuzz.rs
@@ -1,0 +1,426 @@
+//! Fuzz testing CLI command.
+
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use move_core_types::account_address::AccountAddress;
+
+use sui_sandbox_core::fuzz::{
+    classify_params, ClassifiedFunction, FuzzConfig, FuzzReport, FuzzRunner, Outcome, ParamClass,
+};
+use sui_sandbox_core::shared::parsing::parse_type_tag_string;
+
+use super::super::SandboxState;
+
+#[derive(Parser, Debug)]
+#[command(
+    about = "Fuzz a Move function with randomly generated inputs",
+    long_about = "Generates random valid inputs for a Move function's parameter types \
+                  and executes it repeatedly against the local VM. Reports aborts, \
+                  errors, gas exhaustion, and gas usage profiles.\n\n\
+                  Phase 1 supports pure-argument-only functions (bool, integers, \
+                  address, vectors, strings). Functions requiring object inputs \
+                  are analyzed and reported as not yet fuzzable."
+)]
+pub struct FuzzCmd {
+    /// Target: "0xPKG::module::function" or "0xPKG::module" (with --all-functions)
+    pub target: String,
+
+    /// Number of fuzz iterations
+    #[arg(long, short = 'n', default_value = "100")]
+    pub iterations: u64,
+
+    /// Random seed for reproducibility (default: random)
+    #[arg(long)]
+    pub seed: Option<u64>,
+
+    /// Sender address
+    #[arg(long, default_value = "0x0")]
+    pub sender: String,
+
+    /// Gas budget per execution
+    #[arg(long, default_value = "50000000000")]
+    pub gas_budget: u64,
+
+    /// Type arguments (e.g., "0x2::sui::SUI")
+    #[arg(long = "type-arg", num_args(1..))]
+    pub type_args: Vec<String>,
+
+    /// Stop on first abort/error
+    #[arg(long)]
+    pub fail_fast: bool,
+
+    /// Only analyze the function signature (don't execute)
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Fuzz all callable functions in the module
+    #[arg(long)]
+    pub all_functions: bool,
+
+    /// Maximum vector length for generated vector inputs
+    #[arg(long, default_value = "32")]
+    pub max_vector_len: usize,
+}
+
+impl FuzzCmd {
+    pub async fn execute(
+        &self,
+        state: &mut SandboxState,
+        json_output: bool,
+        _verbose: bool,
+    ) -> Result<()> {
+        let sender =
+            AccountAddress::from_hex_literal(&self.sender).context("Invalid sender address")?;
+
+        let type_args = self
+            .type_args
+            .iter()
+            .map(|s| parse_type_tag_string(s))
+            .collect::<Result<Vec<_>>>()?;
+
+        let seed = self.seed.unwrap_or_else(|| {
+            use std::time::{SystemTime, UNIX_EPOCH};
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos() as u64
+        });
+
+        // Parse target
+        let parts: Vec<&str> = self.target.split("::").collect();
+
+        if self.all_functions || parts.len() == 2 {
+            // Module-level fuzzing
+            let (package, module_name) = if parts.len() == 2 {
+                let pkg = AccountAddress::from_hex_literal(parts[0])
+                    .context("Invalid package address")?;
+                (pkg, parts[1].to_string())
+            } else if parts.len() == 3 {
+                // --all-functions with full target; use package::module
+                let pkg = AccountAddress::from_hex_literal(parts[0])
+                    .context("Invalid package address")?;
+                (pkg, parts[1].to_string())
+            } else {
+                return Err(anyhow!(
+                    "Invalid target. Expected '0xPKG::module' or '0xPKG::module::function'"
+                ));
+            };
+
+            let module_path = format!("{}::{}", package.to_hex_literal(), module_name);
+            let functions = state
+                .resolver
+                .list_functions(&module_path)
+                .ok_or_else(|| anyhow!("Module '{}' not found", module_path))?;
+
+            let mut reports = Vec::new();
+            for func_name in &functions {
+                // Check if callable
+                if state
+                    .resolver
+                    .check_function_callable(&package, &module_name, func_name)
+                    .is_err()
+                {
+                    continue;
+                }
+
+                let report = self.fuzz_single(
+                    state,
+                    package,
+                    &module_name,
+                    func_name,
+                    sender,
+                    &type_args,
+                    seed,
+                    json_output,
+                )?;
+                if let Some(r) = report {
+                    reports.push(r);
+                }
+            }
+
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&reports)?);
+            }
+            Ok(())
+        } else if parts.len() == 3 {
+            // Single function
+            let package =
+                AccountAddress::from_hex_literal(parts[0]).context("Invalid package address")?;
+            let module_name = parts[1];
+            let function_name = parts[2];
+
+            state
+                .resolver
+                .check_function_callable(&package, module_name, function_name)?;
+
+            self.fuzz_single(
+                state,
+                package,
+                module_name,
+                function_name,
+                sender,
+                &type_args,
+                seed,
+                json_output,
+            )?;
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "Invalid target format. Expected '0xPKG::module::function' or '0xPKG::module'"
+            ))
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn fuzz_single(
+        &self,
+        state: &SandboxState,
+        package: AccountAddress,
+        module_name: &str,
+        function_name: &str,
+        sender: AccountAddress,
+        type_args: &[move_core_types::language_storage::TypeTag],
+        seed: u64,
+        json_output: bool,
+    ) -> Result<Option<FuzzReport>> {
+        let target = format!(
+            "{}::{}::{}",
+            package.to_hex_literal(),
+            module_name,
+            function_name
+        );
+
+        // Get function signature to classify parameters
+        let sig = state
+            .resolver
+            .get_function_signature(&package, module_name, function_name)
+            .ok_or_else(|| anyhow!("Function '{}' not found", target))?;
+
+        // We need the compiled module to classify params
+        let compiled_module = state
+            .resolver
+            .get_module_by_addr_name(&package, module_name)
+            .ok_or_else(|| anyhow!("Module '{}' not found", module_name))?;
+
+        let classification = classify_params(compiled_module, &sig.parameter_types);
+
+        if self.dry_run {
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "target": target,
+                        "classification": classification,
+                        "verdict": if classification.is_fully_fuzzable { "FULLY_FUZZABLE" } else { "NOT_FUZZABLE" },
+                    }))?
+                );
+            } else {
+                print_dry_run(&target, &classification);
+            }
+            return Ok(None);
+        }
+
+        if !classification.is_fully_fuzzable {
+            if !json_output {
+                print_dry_run(&target, &classification);
+                eprintln!(
+                    "\nSkipping: {} has {} object parameter(s) not fuzzable in Phase 1",
+                    target,
+                    classification.object_count + classification.unfuzzable_count
+                );
+            }
+            return Ok(None);
+        }
+
+        let config = FuzzConfig {
+            iterations: self.iterations,
+            seed,
+            sender,
+            gas_budget: self.gas_budget,
+            type_args: type_args.to_vec(),
+            fail_fast: self.fail_fast,
+            max_vector_len: self.max_vector_len,
+        };
+
+        let runner = FuzzRunner::new(&state.resolver);
+        let report = runner.run(
+            package,
+            module_name,
+            function_name,
+            &classification,
+            &config,
+        )?;
+
+        if json_output {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        } else {
+            print_report(&report);
+        }
+
+        Ok(Some(report))
+    }
+}
+
+fn print_dry_run(target: &str, classification: &ClassifiedFunction) {
+    println!("Function: {}", target);
+    println!();
+    println!("Parameters:");
+    if classification.params.is_empty() {
+        println!("  (none)");
+    }
+    for (i, (type_str, class)) in classification.params.iter().enumerate() {
+        let status = match class {
+            ParamClass::Pure { .. } => "Pure (fuzzable)",
+            ParamClass::SystemInjected { .. } => "SystemInjected (auto-handled)",
+            ParamClass::ObjectRef { mutable, .. } => {
+                if *mutable {
+                    "ObjectRef (mutable) — NOT fuzzable in Phase 1"
+                } else {
+                    "ObjectRef — NOT fuzzable in Phase 1"
+                }
+            }
+            ParamClass::ObjectOwned { .. } => "ObjectOwned — NOT fuzzable in Phase 1",
+            ParamClass::Unfuzzable { reason } => {
+                println!("  [{i}] {type_str:30} -> Unfuzzable: {reason}");
+                continue;
+            }
+        };
+        println!("  [{i}] {type_str:30} -> {status}");
+    }
+    println!();
+    if classification.is_fully_fuzzable {
+        println!(
+            "Verdict: FULLY FUZZABLE ({} pure, {} system-injected)",
+            classification.pure_count, classification.system_count
+        );
+    } else {
+        println!(
+            "Verdict: NOT FUZZABLE — {} parameter(s) require object inputs (Phase 2)",
+            classification.object_count + classification.unfuzzable_count
+        );
+        println!(
+            "Fuzzable: {}/{} (pure: {}, system: {}, object: {}, unfuzzable: {})",
+            classification.pure_count + classification.system_count,
+            classification.params.len(),
+            classification.pure_count,
+            classification.system_count,
+            classification.object_count,
+            classification.unfuzzable_count,
+        );
+    }
+}
+
+fn print_report(report: &FuzzReport) {
+    println!("Fuzz target: {}", report.target);
+    println!();
+    println!("Parameters:");
+    for (i, (type_str, class)) in report.classification.params.iter().enumerate() {
+        let label = match class {
+            ParamClass::Pure { .. } => "Pure",
+            ParamClass::SystemInjected { .. } => "System",
+            _ => "Other",
+        };
+        println!("  [{i}] {type_str:30} -> {label}");
+    }
+    println!();
+    println!(
+        "Results ({} iterations, seed: {}, {}ms):",
+        report.completed_iterations, report.seed, report.elapsed_ms
+    );
+
+    let total = report.completed_iterations.max(1);
+    let success_pct = report.outcomes.successes as f64 / total as f64 * 100.0;
+    println!(
+        "  Success:        {:>6} ({:.1}%)",
+        report.outcomes.successes, success_pct
+    );
+
+    let abort_total: u64 = report.outcomes.aborts.iter().map(|a| a.count).sum();
+    if abort_total > 0 {
+        let abort_pct = abort_total as f64 / total as f64 * 100.0;
+        println!("  Aborts:         {:>6} ({:.1}%)", abort_total, abort_pct);
+        for abort in &report.outcomes.aborts {
+            let loc = abort.location.as_deref().unwrap_or("unknown");
+            println!(
+                "    code {:>5}:    {:>6}  at {}",
+                abort.code, abort.count, loc
+            );
+        }
+    }
+
+    if report.outcomes.gas_exhaustions > 0 {
+        let gas_pct = report.outcomes.gas_exhaustions as f64 / total as f64 * 100.0;
+        println!(
+            "  Gas exhaustion: {:>6} ({:.1}%)",
+            report.outcomes.gas_exhaustions, gas_pct
+        );
+    }
+
+    let error_total: u64 = report.outcomes.errors.iter().map(|e| e.count).sum();
+    if error_total > 0 {
+        let err_pct = error_total as f64 / total as f64 * 100.0;
+        println!("  Errors:         {:>6} ({:.1}%)", error_total, err_pct);
+    }
+
+    // Gas profile
+    println!();
+    println!("Gas profile:");
+    println!(
+        "  min: {}  max: {}  avg: {}  p50: {}  p99: {}",
+        report.gas_profile.min,
+        report.gas_profile.max,
+        report.gas_profile.avg,
+        report.gas_profile.p50,
+        report.gas_profile.p99
+    );
+    if !report.gas_profile.max_input.is_empty() {
+        println!(
+            "  max gas input: [{}]",
+            report.gas_profile.max_input.join(", ")
+        );
+    }
+
+    // Interesting cases
+    if !report.interesting_cases.is_empty() {
+        println!();
+        println!("Interesting cases:");
+        for case in &report.interesting_cases {
+            let outcome_str = match &case.outcome {
+                Outcome::Abort { code, location } => {
+                    let loc = location.as_deref().unwrap_or("");
+                    format!("abort({code}) {loc}")
+                }
+                Outcome::Error { message } => {
+                    let short = if message.len() > 80 {
+                        format!("{}...", &message[..80])
+                    } else {
+                        message.clone()
+                    };
+                    format!("error: {short}")
+                }
+                Outcome::GasExhaustion => "gas exhaustion".into(),
+                Outcome::Success => "success".into(),
+            };
+            println!(
+                "  [iter {}] {} — inputs: [{}]",
+                case.iteration,
+                outcome_str,
+                case.inputs_human.join(", ")
+            );
+
+            // Print reproduce command for abort/error cases
+            if !matches!(case.outcome, Outcome::Success) {
+                let args: Vec<String> = case
+                    .inputs_human
+                    .iter()
+                    .map(|a| format!("--arg {a}"))
+                    .collect();
+                println!(
+                    "    Reproduce: sui-sandbox run {} {}",
+                    report.target,
+                    args.join(" ")
+                );
+            }
+        }
+    }
+}

--- a/src/bin/sandbox_cli/test/mod.rs
+++ b/src/bin/sandbox_cli/test/mod.rs
@@ -1,0 +1,34 @@
+//! Test subcommands for Move function testing.
+
+pub mod fuzz;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use super::SandboxState;
+
+#[derive(Parser, Debug)]
+#[command(about = "Test Move functions (fuzz, property-based, coverage)")]
+pub struct TestCli {
+    #[command(subcommand)]
+    pub command: TestSubcommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TestSubcommand {
+    /// Fuzz a Move function with random inputs
+    Fuzz(fuzz::FuzzCmd),
+}
+
+impl TestCli {
+    pub async fn execute(
+        &self,
+        state: &mut SandboxState,
+        json_output: bool,
+        verbose: bool,
+    ) -> Result<()> {
+        match &self.command {
+            TestSubcommand::Fuzz(cmd) => cmd.execute(state, json_output, verbose).await,
+        }
+    }
+}

--- a/src/bin/sui_sandbox.rs
+++ b/src/bin/sui_sandbox.rs
@@ -52,6 +52,7 @@ use sandbox_cli::{
     replay::ReplayCli,
     run::RunCmd,
     snapshot::SnapshotCmd,
+    test::TestCli,
     tools::ToolsCmd,
     view::ViewCmd,
     SandboxState,
@@ -123,6 +124,9 @@ enum Commands {
     /// Generate sui client commands for deployment (transition helper)
     Bridge(BridgeCmd),
 
+    /// Test Move functions (fuzz, property-based, coverage)
+    Test(TestCli),
+
     /// Extra utilities (polling, streaming, tx simulation)
     Tools(ToolsCmd),
 
@@ -157,6 +161,7 @@ impl Commands {
             Commands::Analyze(_) => "analyze",
             Commands::View(_) => "view",
             Commands::Bridge(_) => "bridge",
+            Commands::Test(_) => "test",
             Commands::Tools(_) => "tools",
             Commands::Init(_) => "init",
             Commands::RunFlow(_) => "run-flow",
@@ -199,6 +204,7 @@ async fn main() -> Result<()> {
         Commands::Analyze(cmd) => cmd.execute(&mut state, json, verbose).await,
         Commands::View(cmd) => cmd.execute(&state, json).await,
         Commands::Bridge(cmd) => cmd.execute(json),
+        Commands::Test(cmd) => cmd.execute(&mut state, json, verbose).await,
         Commands::Tools(cmd) => cmd.execute().await,
         Commands::Init(cmd) => cmd.execute().await,
         Commands::RunFlow(cmd) => cmd.execute(&state_file, &rpc_url, json, verbose).await,


### PR DESCRIPTION
## Summary

- Adds a `test fuzz` CLI command that generates type-aware random inputs for Move functions and executes them against the local VM, reporting aborts, errors, gas exhaustion, and gas usage profiles
- Parameter classifier walks Move bytecode `SignatureToken` to determine which functions are fuzzable (pure args only in Phase 1; object-based params reported as "not yet fuzzable")
- Boundary-heavy value generation: 40% exact edge values (0, 1, MAX, powers of 2), 30% near-boundary (±1-16 offset for off-by-one detection), 30% uniform random — all seeded for deterministic reproducibility
- Gas profiling (min/max/avg/p50/p99) comes for free from `TransactionEffects.gas_used`

### Usage

```bash
# Fuzz a single function
sui-sandbox test fuzz 0x2::math::sqrt_u128 -n 1000 --seed 42

# Analyze all functions in a module (dry-run)
sui-sandbox test fuzz 0x2::math --all-functions --dry-run

# JSON output with type args
sui-sandbox --json test fuzz 0x1::vector::length --type-arg u8 -n 50
```

### Architecture

| Component | File | Purpose |
|-----------|------|---------|
| Classifier | `fuzz/classifier.rs` | `SignatureToken` → `ParamClass` (Pure/SystemInjected/Object/Unfuzzable) |
| Value Generator | `fuzz/value_gen.rs` | Boundary-heavy BCS value generation with seeded PRNG |
| Runner | `fuzz/runner.rs` | Per-iteration VM harness + PTBExecutor execution loop |
| Report | `fuzz/report.rs` | `FuzzReport`, `GasProfile`, `Outcome`, `InterestingCase` |
| CLI | `test/fuzz.rs` | `FuzzCmd` clap struct, human + JSON output formatting |

Phase 2 (coverage-guided fuzzing via VM instruction tracking) is architecturally planned but not implemented in this PR.

## Test plan

- [x] `cargo build` — compiles clean
- [x] `cargo clippy --all-targets` — 0 new warnings
- [x] `cargo test` — 23 new unit tests pass (classifier, value_gen, report, runner)
- [ ] Manual: `sui-sandbox test fuzz 0x1::vector::length --type-arg u8 --dry-run` → "FULLY FUZZABLE"
- [ ] Manual: `sui-sandbox test fuzz 0x1::vector::length --type-arg u8 -n 50 --seed 42` → runs, reports outcomes
- [ ] Manual: Same seed twice → identical reports (determinism)
- [ ] Manual: Target with object params → "NOT FUZZABLE" with param breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)