### PR TITLE
Improve historical GraphQL replay and clean up CI drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,13 @@ jobs:
         working-directory: crates/sui-napi
         run: |
           node -e "
-            const m = require('./sui-sandbox.node');
+            const fs = require('fs');
+            const path = require('path');
+            const candidates = fs.readdirSync('.').filter((name) => name.endsWith('.node'));
+            if (candidates.length !== 1) {
+              throw new Error('Expected exactly one built .node artifact, found: ' + candidates.join(', '));
+            }
+            const m = require(path.resolve(candidates[0]));
             console.log('version:', m.version());
             const keys = Object.keys(m).sort();
             console.log('exports:', keys.length);

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ sui-official/
 
 # gRPC object cache (generated at runtime)
 grpc_object_cache.json
+sui_schema.graphql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6390,7 +6390,7 @@ dependencies = [
 
 [[package]]
 name = "sui-python"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/sui-napi/src/lib.rs
+++ b/crates/sui-napi/src/lib.rs
@@ -64,8 +64,7 @@ use sui_sandbox_core::orchestrator::{
 };
 use sui_sandbox_core::ptb_universe::{
     run_with_args as core_run_ptb_universe, Args as CorePtbUniverseArgs,
-    CheckpointSource as CoreCheckpointSource,
-    DEFAULT_LATEST as CORE_PTB_UNIVERSE_DEFAULT_LATEST,
+    CheckpointSource as CoreCheckpointSource, DEFAULT_LATEST as CORE_PTB_UNIVERSE_DEFAULT_LATEST,
     DEFAULT_MAX_PTBS as CORE_PTB_UNIVERSE_DEFAULT_MAX_PTBS,
     DEFAULT_STREAM_TIMEOUT_SECS as CORE_PTB_UNIVERSE_DEFAULT_STREAM_TIMEOUT_SECS,
     DEFAULT_TOP_PACKAGES as CORE_PTB_UNIVERSE_DEFAULT_TOP_PACKAGES,
@@ -394,10 +393,18 @@ pub async fn ptb_universe(
 ) -> napi::Result<serde_json::Value> {
     let source_str = source.as_deref().unwrap_or("walrus");
     let source_parsed = CoreCheckpointSource::parse(source_str).map_err(to_napi_err)?;
-    let latest_val = latest.map(|v| v as u64).unwrap_or(CORE_PTB_UNIVERSE_DEFAULT_LATEST);
-    let top_packages_val = top_packages.map(|v| v as usize).unwrap_or(CORE_PTB_UNIVERSE_DEFAULT_TOP_PACKAGES);
-    let max_ptbs_val = max_ptbs.map(|v| v as usize).unwrap_or(CORE_PTB_UNIVERSE_DEFAULT_MAX_PTBS);
-    let stream_timeout_val = stream_timeout_secs.map(|v| v as u64).unwrap_or(CORE_PTB_UNIVERSE_DEFAULT_STREAM_TIMEOUT_SECS);
+    let latest_val = latest
+        .map(|v| v as u64)
+        .unwrap_or(CORE_PTB_UNIVERSE_DEFAULT_LATEST);
+    let top_packages_val = top_packages
+        .map(|v| v as usize)
+        .unwrap_or(CORE_PTB_UNIVERSE_DEFAULT_TOP_PACKAGES);
+    let max_ptbs_val = max_ptbs
+        .map(|v| v as usize)
+        .unwrap_or(CORE_PTB_UNIVERSE_DEFAULT_MAX_PTBS);
+    let stream_timeout_val = stream_timeout_secs
+        .map(|v| v as u64)
+        .unwrap_or(CORE_PTB_UNIVERSE_DEFAULT_STREAM_TIMEOUT_SECS);
     let out_dir_path = PathBuf::from(
         out_dir
             .as_deref()
@@ -640,7 +647,9 @@ pub async fn extract_interface(
     extract_interface_inner(
         package_id.as_deref(),
         bytecode_dir.as_deref(),
-        rpc_url.as_deref().unwrap_or("https://fullnode.mainnet.sui.io:443"),
+        rpc_url
+            .as_deref()
+            .unwrap_or("https://fullnode.mainnet.sui.io:443"),
     )
     .map_err(to_napi_err)
 }
@@ -677,10 +686,16 @@ pub async fn replay(
     analyze_mm2: Option<bool>,
     verbose: Option<bool>,
 ) -> napi::Result<serde_json::Value> {
-    let rpc = rpc_url.as_deref().unwrap_or("https://fullnode.mainnet.sui.io:443");
+    let rpc = rpc_url
+        .as_deref()
+        .unwrap_or("https://fullnode.mainnet.sui.io:443");
     let source_str = source.as_deref().unwrap_or("hybrid");
     let vm_only_val = vm_only.unwrap_or(false);
-    let allow_fallback_val = if vm_only_val { false } else { allow_fallback.unwrap_or(true) };
+    let allow_fallback_val = if vm_only_val {
+        false
+    } else {
+        allow_fallback.unwrap_or(true)
+    };
     let no_prefetch_val = no_prefetch.unwrap_or(false);
     let verbose_val = verbose.unwrap_or(false);
     let compare_val = compare.unwrap_or(false);
@@ -694,8 +709,10 @@ pub async fn replay(
 
     let profile_parsed = parse_replay_profile(profile.as_deref()).map_err(to_napi_err)?;
     let _profile_env = workflow_apply_profile_env(profile_parsed);
-    let fetch_strategy_parsed = parse_replay_fetch_strategy(fetch_strategy.as_deref()).map_err(to_napi_err)?;
-    let no_prefetch_effective = no_prefetch_val || fetch_strategy_parsed == WorkflowFetchStrategy::Eager;
+    let fetch_strategy_parsed =
+        parse_replay_fetch_strategy(fetch_strategy.as_deref()).map_err(to_napi_err)?;
+    let no_prefetch_effective =
+        no_prefetch_val || fetch_strategy_parsed == WorkflowFetchStrategy::Eager;
 
     let source_is_local = source_str.eq_ignore_ascii_case("local");
     let use_local_cache = source_is_local || cache_dir.is_some();
@@ -734,9 +751,11 @@ pub async fn replay(
     }
 
     if use_local_cache {
-        let d = digest
-            .as_deref()
-            .ok_or_else(|| to_napi_err(anyhow!("digest is required when replaying from cache_dir/source='local'")))?;
+        let d = digest.as_deref().ok_or_else(|| {
+            to_napi_err(anyhow!(
+                "digest is required when replaying from cache_dir/source='local'"
+            ))
+        })?;
         let cache = cache_dir
             .as_deref()
             .map(PathBuf::from)
@@ -814,7 +833,9 @@ pub async fn import_state(
 
 /// Deserialize transaction BCS bytes into structured replay transaction JSON.
 #[napi]
-pub fn deserialize_transaction(raw_bcs: napi::bindgen_prelude::Buffer) -> napi::Result<serde_json::Value> {
+pub fn deserialize_transaction(
+    raw_bcs: napi::bindgen_prelude::Buffer,
+) -> napi::Result<serde_json::Value> {
     deserialize_transaction_inner(&raw_bcs).map_err(to_napi_err)
 }
 
@@ -859,7 +880,9 @@ pub fn json_to_bcs(
 
 /// Convert Sui TransactionData JSON into raw transaction BCS bytes.
 #[napi]
-pub fn transaction_json_to_bcs(transaction_json: String) -> napi::Result<napi::bindgen_prelude::Buffer> {
+pub fn transaction_json_to_bcs(
+    transaction_json: String,
+) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let bytes = transaction_json_to_bcs_inner(&transaction_json).map_err(to_napi_err)?;
     Ok(napi::bindgen_prelude::Buffer::from(bytes))
 }
@@ -1025,7 +1048,8 @@ pub async fn protocol_prepare(
     output_path: Option<String>,
 ) -> napi::Result<serde_json::Value> {
     let proto = protocol.as_deref().unwrap_or("generic");
-    let resolved = resolve_protocol_package_id(proto, package_id.as_deref()).map_err(to_napi_err)?;
+    let resolved =
+        resolve_protocol_package_id(proto, package_id.as_deref()).map_err(to_napi_err)?;
     prepare_package_context_inner(
         &resolved,
         resolve_deps.unwrap_or(true),
@@ -1189,9 +1213,9 @@ fn call_view_function_inner(
     fetch_deps: bool,
     bytecode_dirs: &HashMap<String, String>,
 ) -> Result<serde_json::Value> {
+    use move_core_types::identifier::Identifier;
     use sui_sandbox_core::ptb::{Argument, Command, ObjectInput, PTBExecutor};
     use sui_sandbox_core::vm::{SimulationConfig, VMHarness};
-    use move_core_types::identifier::Identifier;
 
     // 1. Build LocalModuleResolver with sui framework
     let mut resolver = sui_sandbox_core::resolver::LocalModuleResolver::with_sui_framework()?;
@@ -1199,15 +1223,17 @@ fn call_view_function_inner(
     // 1a. Load any local bytecode directories
     let zero_addr = AccountAddress::from_hex_literal("0x0").unwrap();
     for (pkg_addr_str, dir_path) in bytecode_dirs {
-        let count = resolver.load_from_dir(std::path::Path::new(dir_path))
+        let count = resolver
+            .load_from_dir(std::path::Path::new(dir_path))
             .with_context(|| format!("Failed to load bytecode from directory: {}", dir_path))?;
         if count == 0 {
             eprintln!("Warning: no .mv files found in {}", dir_path);
             continue;
         }
         // Set up alias from the deployed address to 0x0 (local build address)
-        let addr = AccountAddress::from_hex_literal(pkg_addr_str)
-            .with_context(|| format!("invalid package address for bytecode_dir: {}", pkg_addr_str))?;
+        let addr = AccountAddress::from_hex_literal(pkg_addr_str).with_context(|| {
+            format!("invalid package address for bytecode_dir: {}", pkg_addr_str)
+        })?;
         if addr != zero_addr {
             resolver.add_address_alias(addr, zero_addr);
         }
@@ -1415,8 +1441,10 @@ fn call_view_function_inner(
 
     // 5. Set up child fetcher
     if !child_objects.is_empty() || fetch_child_objects {
-        let mut child_map: HashMap<(AccountAddress, AccountAddress), (move_core_types::language_storage::TypeTag, Vec<u8>)> =
-            HashMap::new();
+        let mut child_map: HashMap<
+            (AccountAddress, AccountAddress),
+            (move_core_types::language_storage::TypeTag, Vec<u8>),
+        > = HashMap::new();
         for (parent_id_str, children) in &child_objects {
             let parent_addr = AccountAddress::from_hex_literal(parent_id_str)
                 .with_context(|| format!("invalid parent_id: {}", parent_id_str))?;
@@ -1600,28 +1628,41 @@ pub async fn call_view_function(
     let mut parsed_obj_inputs: Vec<(String, Vec<u8>, String, bool, bool)> = Vec::new();
     if let Some(inputs) = object_inputs {
         for obj in &inputs {
-            let object_id = obj.get("objectId").or(obj.get("object_id"))
+            let object_id = obj
+                .get("objectId")
+                .or(obj.get("object_id"))
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| to_napi_err(anyhow!("missing 'objectId' in objectInputs")))?
                 .to_string();
-            let bcs_b64 = obj.get("bcsBytes").or(obj.get("bcs_bytes"))
+            let bcs_b64 = obj
+                .get("bcsBytes")
+                .or(obj.get("bcs_bytes"))
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| to_napi_err(anyhow!("missing 'bcsBytes' in objectInputs")))?;
             let bcs_bytes = base64::engine::general_purpose::STANDARD
                 .decode(bcs_b64)
                 .map_err(|e| to_napi_err(anyhow!("invalid base64 in bcsBytes: {}", e)))?;
-            let type_tag = obj.get("typeTag").or(obj.get("type_tag"))
+            let type_tag = obj
+                .get("typeTag")
+                .or(obj.get("type_tag"))
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| to_napi_err(anyhow!("missing 'typeTag' in objectInputs")))?
                 .to_string();
-            let is_shared = obj.get("isShared").or(obj.get("is_shared"))
-                .and_then(|v| v.as_bool()).unwrap_or(false);
-            let mutable = obj.get("mutable")
-                .and_then(|v| v.as_bool()).unwrap_or(false);
+            let is_shared = obj
+                .get("isShared")
+                .or(obj.get("is_shared"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let mutable = obj
+                .get("mutable")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
 
             // Legacy owner field
             let owner = obj.get("owner").and_then(|v| v.as_str());
-            let (final_shared, final_mutable) = if obj.get("isShared").is_none() && obj.get("is_shared").is_none() {
+            let (final_shared, final_mutable) = if obj.get("isShared").is_none()
+                && obj.get("is_shared").is_none()
+            {
                 match owner.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
                     Some("shared") => (true, obj.get("mutable").and_then(|v| v.as_bool()).unwrap_or(true)),
                     Some("immutable") | Some("address_owned") => (false, mutable),
@@ -1652,17 +1693,23 @@ pub async fn call_view_function(
                 if let Some(children) = children_val.as_array() {
                     let mut child_vec = Vec::new();
                     for child in children {
-                        let child_id = child.get("childId").or(child.get("child_id"))
+                        let child_id = child
+                            .get("childId")
+                            .or(child.get("child_id"))
                             .and_then(|v| v.as_str())
                             .ok_or_else(|| to_napi_err(anyhow!("missing 'childId'")))?
                             .to_string();
-                        let bcs_b64 = child.get("bcsBytes").or(child.get("bcs_bytes"))
+                        let bcs_b64 = child
+                            .get("bcsBytes")
+                            .or(child.get("bcs_bytes"))
                             .and_then(|v| v.as_str())
                             .ok_or_else(|| to_napi_err(anyhow!("missing 'bcsBytes'")))?;
                         let bcs = base64::engine::general_purpose::STANDARD
                             .decode(bcs_b64)
                             .map_err(|e| to_napi_err(anyhow!("invalid base64: {}", e)))?;
-                        let tt = child.get("typeTag").or(child.get("type_tag"))
+                        let tt = child
+                            .get("typeTag")
+                            .or(child.get("type_tag"))
                             .and_then(|v| v.as_str())
                             .ok_or_else(|| to_napi_err(anyhow!("missing 'typeTag'")))?
                             .to_string();
@@ -1711,7 +1758,9 @@ pub async fn call_view_function(
                         if let Some(s) = m.as_str() {
                             let bytes = base64::engine::general_purpose::STANDARD
                                 .decode(s)
-                                .map_err(|e| to_napi_err(anyhow!("invalid base64 module: {}", e)))?;
+                                .map_err(|e| {
+                                    to_napi_err(anyhow!("invalid base64 module: {}", e))
+                                })?;
                             bytecodes.push(bytes);
                         }
                     }
@@ -1720,30 +1769,54 @@ pub async fn call_view_function(
             }
 
             if let Some(a) = obj.get("aliases").and_then(|v| v.as_object()) {
-                for (k, v) in a { if let Some(s) = v.as_str() { parsed_aliases.insert(k.clone(), s.to_string()); } }
+                for (k, v) in a {
+                    if let Some(s) = v.as_str() {
+                        parsed_aliases.insert(k.clone(), s.to_string());
+                    }
+                }
             }
             if let Some(lu) = obj.get("linkage_upgrades").and_then(|v| v.as_object()) {
-                for (k, v) in lu { if let Some(s) = v.as_str() { parsed_linkage_upgrades.insert(k.clone(), s.to_string()); } }
+                for (k, v) in lu {
+                    if let Some(s) = v.as_str() {
+                        parsed_linkage_upgrades.insert(k.clone(), s.to_string());
+                    }
+                }
             }
             if let Some(ri) = obj.get("package_runtime_ids").and_then(|v| v.as_object()) {
-                for (k, v) in ri { if let Some(s) = v.as_str() { parsed_runtime_ids.insert(k.clone(), s.to_string()); } }
+                for (k, v) in ri {
+                    if let Some(s) = v.as_str() {
+                        parsed_runtime_ids.insert(k.clone(), s.to_string());
+                    }
+                }
             }
             if let Some(pl) = obj.get("package_linkage").and_then(|v| v.as_object()) {
                 for (k, v) in pl {
                     if let Some(inner) = v.as_object() {
                         let mut map = HashMap::new();
-                        for (ik, iv) in inner { if let Some(s) = iv.as_str() { map.insert(ik.clone(), s.to_string()); } }
+                        for (ik, iv) in inner {
+                            if let Some(s) = iv.as_str() {
+                                map.insert(ik.clone(), s.to_string());
+                            }
+                        }
                         parsed_pkg_linkage.insert(k.clone(), map);
                     }
                 }
             }
             if let Some(pv) = obj.get("package_versions").and_then(|v| v.as_object()) {
-                for (k, v) in pv { if let Some(n) = v.as_u64() { parsed_pkg_versions.insert(k.clone(), n); } }
+                for (k, v) in pv {
+                    if let Some(n) = v.as_u64() {
+                        parsed_pkg_versions.insert(k.clone(), n);
+                    }
+                }
             }
         }
     }
 
-    let effective_fetch_deps = if historical_payload_mode { false } else { fetch_deps.unwrap_or(true) };
+    let effective_fetch_deps = if historical_payload_mode {
+        false
+    } else {
+        fetch_deps.unwrap_or(true)
+    };
 
     // Parse bytecode_dirs: { "0xaddr": "/path/to/build/pkg" }
     let mut parsed_bytecode_dirs: HashMap<String, String> = HashMap::new();
@@ -1872,14 +1945,24 @@ pub async fn historical_series_from_points(
 
     let runs = if let Some(fields) = schema_fields.as_ref() {
         ReplayOrchestrator::execute_historical_series_with_schema_and_options(
-            &parsed_points, &request, cmd_idx, fields,
-            grpc_endpoint.as_deref(), grpc_api_key.as_deref(), &options,
-        ).map_err(to_napi_err)?
+            &parsed_points,
+            &request,
+            cmd_idx,
+            fields,
+            grpc_endpoint.as_deref(),
+            grpc_api_key.as_deref(),
+            &options,
+        )
+        .map_err(to_napi_err)?
     } else {
         ReplayOrchestrator::execute_historical_series_with_options(
-            &parsed_points, &request,
-            grpc_endpoint.as_deref(), grpc_api_key.as_deref(), &options,
-        ).map_err(to_napi_err)?
+            &parsed_points,
+            &request,
+            grpc_endpoint.as_deref(),
+            grpc_api_key.as_deref(),
+            &options,
+        )
+        .map_err(to_napi_err)?
     };
     let summary = ReplayOrchestrator::summarize_historical_series_runs(&runs);
     Ok(serde_json::json!({
@@ -1978,7 +2061,9 @@ pub fn historical_decode_return_u64s(
                 values
                     .into_iter()
                     .map(|bytes| {
-                        if bytes.len() < 8 { return None; }
+                        if bytes.len() < 8 {
+                            return None;
+                        }
                         let mut buf = [0u8; 8];
                         buf.copy_from_slice(&bytes[..8]);
                         Some(u64::from_le_bytes(buf) as f64)
@@ -2062,7 +2147,8 @@ fn fuzz_function_inner(
         for fw in ["0x1", "0x2", "0x3"] {
             loaded.insert(AccountAddress::from_hex_literal(fw).unwrap());
         }
-        let count = r.load_from_dir(std::path::Path::new(dir))
+        let count = r
+            .load_from_dir(std::path::Path::new(dir))
             .with_context(|| format!("Failed to load bytecode from directory: {}", dir))?;
         if count == 0 {
             return Err(anyhow!("No .mv files found in {}", dir));
@@ -2100,7 +2186,9 @@ fn fuzz_function_inner(
         .ok_or_else(|| {
             anyhow!(
                 "Function '{}::{}::{}' not found",
-                package_id, module, function
+                package_id,
+                module,
+                function
             )
         })?;
 
@@ -2346,7 +2434,10 @@ impl OrchestrationSession {
             discover_package_id,
             source,
             state_file,
-            context_tmp.as_ref().and_then(|p| p.to_str()).map(String::from),
+            context_tmp
+                .as_ref()
+                .and_then(|p| p.to_str())
+                .map(String::from),
             cache_dir,
             walrus_network,
             walrus_caching_url,

--- a/crates/sui-napi/src/replay_api.rs
+++ b/crates/sui-napi/src/replay_api.rs
@@ -25,9 +25,7 @@ fn parse_analysis_u64(value: &serde_json::Value, key: &str) -> u64 {
         .unwrap_or(0)
 }
 
-fn parse_analysis_lists(
-    value: &serde_json::Value,
-) -> (Vec<String>, Vec<String>, Vec<String>) {
+fn parse_analysis_lists(value: &serde_json::Value) -> (Vec<String>, Vec<String>, Vec<String>) {
     let missing_inputs = parse_json_string_list(
         value
             .get("analysis")
@@ -125,10 +123,7 @@ fn replay_impl(
             .map(PathBuf::from)
             .unwrap_or_else(default_local_cache_dir);
         let provider = FileStateProvider::new(&cache_path).with_context(|| {
-            format!(
-                "Failed to open local replay cache {}",
-                cache_path.display()
-            )
+            format!("Failed to open local replay cache {}", cache_path.display())
         })?;
         let replay_state = provider.get_state(digest)?;
         return replay_loaded_state_inner(
@@ -205,12 +200,8 @@ fn protocol_run_impl(
 ) -> napi::Result<serde_json::Value> {
     let resolved_package_id =
         resolve_protocol_package_id(protocol, package_id).map_err(to_napi_err)?;
-    let prepared = prepare_package_context_inner(
-        &resolved_package_id,
-        resolve_deps,
-        context_path,
-    )
-    .map_err(to_napi_err)?;
+    let prepared = prepare_package_context_inner(&resolved_package_id, resolve_deps, context_path)
+        .map_err(to_napi_err)?;
 
     let context_tmp = if context_path.is_some() {
         None
@@ -503,10 +494,10 @@ pub fn analyze_replay(
         prefetch_limit,
         auto_system_objects,
         no_prefetch,
-        Some(false),  // compare
-        Some(true),   // analyze_only
-        Some(false),  // synthesize_missing
-        Some(false),  // self_heal_dynamic_fields
+        Some(false), // compare
+        Some(true),  // analyze_only
+        Some(false), // synthesize_missing
+        Some(false), // self_heal_dynamic_fields
         analyze_mm2,
         verbose,
     )
@@ -617,10 +608,10 @@ pub fn replay_effects(
         auto_system_objects,
         no_prefetch,
         compare,
-        Some(false),  // analyze_only
+        Some(false), // analyze_only
         synthesize_missing,
         self_heal_dynamic_fields,
-        Some(false),  // analyze_mm2
+        Some(false), // analyze_mm2
         verbose,
     )?;
 
@@ -663,9 +654,7 @@ pub fn replay_effects(
 ///
 /// Accepts a replay result JSON value and returns a classification object.
 #[napi]
-pub fn classify_replay_result(
-    result: serde_json::Value,
-) -> napi::Result<serde_json::Value> {
+pub fn classify_replay_result(result: serde_json::Value) -> napi::Result<serde_json::Value> {
     let classified = classify_replay_output(&result);
     Ok(classified)
 }
@@ -722,11 +711,11 @@ pub fn dynamic_field_diagnostics(
         Some(pd),
         Some(pl),
         auto_system_objects,
-        Some(true),   // no_prefetch = true (baseline)
-        Some(false),  // compare
-        Some(true),   // analyze_only
-        Some(false),  // synthesize_missing
-        Some(false),  // self_heal_dynamic_fields
+        Some(true),  // no_prefetch = true (baseline)
+        Some(false), // compare
+        Some(true),  // analyze_only
+        Some(false), // synthesize_missing
+        Some(false), // self_heal_dynamic_fields
         analyze_mm2,
         verbose,
     )?;
@@ -774,11 +763,11 @@ pub fn dynamic_field_diagnostics(
         Some(pd),
         Some(pl),
         auto_system_objects,
-        Some(false),  // no_prefetch = false (prefetch enabled)
-        Some(false),  // compare
-        Some(true),   // analyze_only
-        Some(false),  // synthesize_missing
-        Some(false),  // self_heal_dynamic_fields
+        Some(false), // no_prefetch = false (prefetch enabled)
+        Some(false), // compare
+        Some(true),  // analyze_only
+        Some(false), // synthesize_missing
+        Some(false), // self_heal_dynamic_fields
         analyze_mm2,
         verbose,
     )?;

--- a/crates/sui-napi/src/session_api.rs
+++ b/crates/sui-napi/src/session_api.rs
@@ -185,10 +185,7 @@ pub fn snapshot_save(
 
 /// Load a named snapshot into the session state file (CLI parity for `snapshot load`).
 #[napi]
-pub fn snapshot_load(
-    name: String,
-    state_file: Option<String>,
-) -> napi::Result<serde_json::Value> {
+pub fn snapshot_load(name: String, state_file: Option<String>) -> napi::Result<serde_json::Value> {
     let state_path = state_file
         .map(PathBuf::from)
         .unwrap_or_else(default_state_file_path);

--- a/crates/sui-napi/src/workflow_api.rs
+++ b/crates/sui-napi/src/workflow_api.rs
@@ -49,8 +49,7 @@ pub fn workflow_init(
     let force = force.unwrap_or(false);
     let checkpoint_u64 = checkpoint.map(|v| v as u64);
 
-    let parsed_template =
-        parse_workflow_template(template_str).map_err(to_napi_err)?;
+    let parsed_template = parse_workflow_template(template_str).map_err(to_napi_err)?;
     let resolved_digest = digest
         .as_deref()
         .map(str::trim)
@@ -85,8 +84,7 @@ pub fn workflow_init(
     }
     spec.validate().map_err(to_napi_err)?;
 
-    let parsed_format =
-        parse_workflow_output_format(format.as_deref()).map_err(to_napi_err)?;
+    let parsed_format = parse_workflow_output_format(format.as_deref()).map_err(to_napi_err)?;
     let format_hint = parsed_format.unwrap_or(WorkflowOutputFormat::Json);
     let resolved_output_path = output_path
         .as_deref()
@@ -245,9 +243,11 @@ pub fn workflow_auto(
         None
     };
 
-    let resolved_digest = explicit_digest
-        .clone()
-        .or_else(|| discovered_target.as_ref().map(|target| target.digest.clone()));
+    let resolved_digest = explicit_digest.clone().or_else(|| {
+        discovered_target
+            .as_ref()
+            .map(|target| target.digest.clone())
+    });
     let include_replay = resolved_digest.is_some();
     let resolved_checkpoint = if include_replay {
         if let Some(target) = discovered_target.as_ref() {
@@ -274,8 +274,7 @@ pub fn workflow_auto(
             );
         } else {
             missing_inputs.push("digest".to_string());
-            missing_inputs
-                .push("checkpoint (optional; default inferred per template)".to_string());
+            missing_inputs.push("checkpoint (optional; default inferred per template)".to_string());
         }
     }
 
@@ -294,9 +293,8 @@ pub fn workflow_auto(
     .map_err(to_napi_err)?;
 
     let pkg_suffix = short_package_id(package_id_trimmed);
-    spec.name = Some(
-        name.unwrap_or_else(|| format!("auto_{}_{}", inferred_template.key(), pkg_suffix)),
-    );
+    spec.name =
+        Some(name.unwrap_or_else(|| format!("auto_{}_{}", inferred_template.key(), pkg_suffix)));
     spec.description = Some(format!(
         "Auto draft adapter generated from package {} (template: {}).",
         package_id_trimmed,
@@ -304,8 +302,7 @@ pub fn workflow_auto(
     ));
     spec.validate().map_err(to_napi_err)?;
 
-    let parsed_format =
-        parse_workflow_output_format(format.as_deref()).map_err(to_napi_err)?;
+    let parsed_format = parse_workflow_output_format(format.as_deref()).map_err(to_napi_err)?;
     let format_hint = parsed_format.unwrap_or(WorkflowOutputFormat::Json);
     let resolved_output_path = output_path
         .as_deref()

--- a/crates/sui-python/Cargo.toml
+++ b/crates/sui-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-python"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 description = "Python bindings for Sui Move package analysis and transaction replay"
 

--- a/crates/sui-python/pyproject.toml
+++ b/crates/sui-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sui-sandbox"
-version = "0.22.1"
+version = "0.22.2"
 description = "Python bindings for Sui Move package analysis and transaction replay"
 requires-python = ">=3.9"
 readme = "README.md"

--- a/crates/sui-sandbox-core/src/natives.rs
+++ b/crates/sui-sandbox-core/src/natives.rs
@@ -1932,6 +1932,9 @@ fn add_dynamic_field_natives(
         "hash_type_and_key",
         make_native(move |ctx, mut ty_args, mut args| {
             use crate::sandbox_runtime::SharedObjectRuntime;
+            if std::env::var("SUI_DEBUG_DF_FETCH").is_ok() {
+                eprintln!("[hash_type_and_key] ENTERED native");
+            }
 
             let key_ty = ty_args.pop().ok_or_else(|| {
                 move_binary_format::errors::PartialVMError::new(
@@ -2181,6 +2184,9 @@ fn add_dynamic_field_natives(
             use move_vm_types::values::StructRef;
 
             debug_native!("[borrow_child_object] ENTERING NATIVE, ty_args={}, args={}", ty_args.len(), args.len());
+            if std::env::var("SUI_DEBUG_DF_FETCH").is_ok() {
+                eprintln!("[borrow_child_object] ENTERED native");
+            }
             use std::io::Write;
             std::io::stderr().flush().ok();
 
@@ -2817,6 +2823,12 @@ fn add_dynamic_field_natives(
             debug_native!("[has_child_object_with_ty] fetched_tag={:?}", fetched_tag);
             debug_native!("[has_child_object_with_ty] child_tag={:?}", child_tag);
             debug_native!("[has_child_object_with_ty] type_matches={}", type_matches);
+                    if std::env::var("SUI_DEBUG_DF_FETCH").is_ok() && !type_matches {
+                        eprintln!(
+                            "[has_child_object_with_ty] TYPE_MISMATCH parent={} child={}\n  fetched_tag={:?}\n  child_tag={:?}",
+                            parent.to_hex_literal(), child_id.to_hex_literal(), fetched_tag, child_tag
+                        );
+                    }
                     if type_matches {
                         // Add to shared state for future lookups
                         {
@@ -2846,6 +2858,12 @@ fn add_dynamic_field_natives(
                     }
                 } else {
             debug_native!("[has_child_object_with_ty] try_fetch_child returned None");
+                    if std::env::var("SUI_DEBUG_DF_FETCH").is_ok() {
+                        eprintln!(
+                            "[has_child_object_with_ty] MISS parent={} child={} expected_tag={:?}",
+                            parent.to_hex_literal(), child_id.to_hex_literal(), child_tag
+                        );
+                    }
                     false
                 }
             } else {

--- a/crates/sui-sandbox-core/src/ptb.rs
+++ b/crates/sui-sandbox-core/src/ptb.rs
@@ -2858,7 +2858,19 @@ impl<'a, 'b> PTBExecutor<'a, 'b> {
                 args,
             } => self.execute_move_call(package, module, function, type_args, args),
 
-            Command::SplitCoins { coin, amounts } => self.execute_split_coins(coin, amounts),
+            Command::SplitCoins {
+                ref coin,
+                ref amounts,
+            } => {
+                if std::env::var("SUI_DEBUG_DF_FETCH").is_ok() {
+                    eprintln!(
+                        "[execute_command] SplitCoins coin={:?} amounts={}",
+                        coin,
+                        amounts.len()
+                    );
+                }
+                self.execute_split_coins(*coin, amounts.clone())
+            }
 
             Command::MergeCoins {
                 destination,
@@ -2905,6 +2917,14 @@ impl<'a, 'b> PTBExecutor<'a, 'b> {
         type_args: Vec<TypeTag>,
         args: Vec<Argument>,
     ) -> Result<CommandResult> {
+        if std::env::var("SUI_DEBUG_DF_FETCH").is_ok() {
+            eprintln!(
+                "[execute_move_call] {}::{}::{}",
+                package.to_hex_literal(),
+                module,
+                function,
+            );
+        }
         // GAS COIN CHECK: Gas coin can only be used with TransferObjects
         self.check_gas_coin_usage(&args, "MoveCall")?;
 

--- a/crates/sui-sandbox-core/src/sandbox_runtime.rs
+++ b/crates/sui-sandbox-core/src/sandbox_runtime.rs
@@ -1815,6 +1815,15 @@ impl SharedObjectRuntime {
         parent_id: AccountAddress,
         child_id: AccountAddress,
     ) -> Option<(TypeTag, Vec<u8>)> {
+        if std::env::var("SUI_DEBUG_DF_FETCH").is_ok() {
+            eprintln!(
+                "[try_fetch_child] parent={} child={} has_fetcher={} has_key_fetcher={}",
+                parent_id.to_hex_literal(),
+                child_id.to_hex_literal(),
+                self.child_fetcher.is_some(),
+                self.key_based_child_fetcher.is_some(),
+            );
+        }
         // Always record the access for tracing
         self.record_child_access(child_id);
 
@@ -1838,6 +1847,13 @@ impl SharedObjectRuntime {
             }
         }
 
+        if std::env::var("SUI_DEBUG_DF_FETCH").is_ok() {
+            eprintln!(
+                "[try_fetch_child] MISS parent={} child={}",
+                parent_id.to_hex_literal(),
+                child_id.to_hex_literal()
+            );
+        }
         None
     }
 }

--- a/crates/sui-sandbox-core/src/vm.rs
+++ b/crates/sui-sandbox-core/src/vm.rs
@@ -2574,6 +2574,14 @@ impl<'a> VMHarness<'a> {
     /// Create VM extensions with a SharedObjectRuntime that syncs with our persistent state.
     /// This allows dynamic field operations to persist across multiple MoveCall executions.
     fn create_extensions(&self) -> NativeContextExtensions<'static> {
+        if std::env::var("SUI_DEBUG_DF_FETCH").is_ok() {
+            eprintln!(
+                "[create_extensions] use_sui_natives={} has_child_fetcher={} has_key_fetcher={}",
+                self.config.use_sui_natives,
+                self.child_fetcher.is_some(),
+                self.key_based_child_fetcher.is_some(),
+            );
+        }
         let mut extensions = NativeContextExtensions::default();
 
         // If using Sui natives mode and we have Sui extensions, use those

--- a/crates/sui-state-fetcher/src/fetch_utils.rs
+++ b/crates/sui-state-fetcher/src/fetch_utils.rs
@@ -143,21 +143,23 @@ pub fn fetch_child_object(
     let gql = provider.graphql();
     let id_str = child_id.to_hex_literal();
 
-    // Try GraphQL at checkpoint
-    if let Some(cp) = checkpoint {
-        if let Ok(obj) = gql.fetch_object_at_checkpoint(&id_str, cp) {
-            if obj.version <= max_version {
-                if let (Some(type_str), Some(bcs_b64)) = (obj.type_string, obj.bcs_base64) {
-                    if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(&bcs_b64) {
-                        if let Some(tag) = sui_sandbox_types::parse_type_tag(&type_str) {
-                            if debug_df {
-                                eprintln!(
-                                    "[df_fetch] checkpoint child={} version={}",
-                                    id_str, obj.version
-                                );
-                            }
-                            return Some((tag, bytes, obj.version));
+    // Use objectVersionsBefore to find the most recent version at or before
+    // max_version. This is the primary historical lookup — we skip the
+    // @snapshot-based fetch_object_at_checkpoint because mainnet's GraphQL
+    // endpoint does not support the @snapshot directive, and the wasted API
+    // call adds latency without benefit.
+    if max_version > 0 {
+        if let Ok(obj) = gql.fetch_object_version_before(&id_str, max_version + 1) {
+            if let (Some(type_str), Some(bcs_b64)) = (obj.type_string, obj.bcs_base64) {
+                if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(&bcs_b64) {
+                    if let Some(tag) = sui_sandbox_types::parse_type_tag(&type_str) {
+                        if debug_df {
+                            eprintln!(
+                                "[df_fetch] version_before child={} version={}",
+                                id_str, obj.version
+                            );
                         }
+                        return Some((tag, bytes, obj.version));
                     }
                 }
             }
@@ -174,16 +176,18 @@ pub fn fetch_child_object(
         return None;
     }
 
-    // Try gRPC latest
-    if let Some((tag, bytes, version)) = fetch_object_via_grpc(provider, &id_str, None) {
-        if version <= max_version {
-            if debug_df {
-                eprintln!(
-                    "[df_fetch] grpc latest child={} version={}",
-                    id_str, version
-                );
+    // Try gRPC latest (skip in graphql-only mode)
+    if !provider.is_graphql_only() {
+        if let Some((tag, bytes, version)) = fetch_object_via_grpc(provider, &id_str, None) {
+            if version <= max_version {
+                if debug_df {
+                    eprintln!(
+                        "[df_fetch] grpc latest child={} version={}",
+                        id_str, version
+                    );
+                }
+                return Some((tag, bytes, version));
             }
-            return Some((tag, bytes, version));
         }
     }
 
@@ -203,6 +207,14 @@ pub fn fetch_child_object(
         }
     }
 
+    if debug_df {
+        eprintln!(
+            "[df_fetch] MISS child={} checkpoint={:?} max_version={}",
+            child_id.to_hex_literal(),
+            checkpoint,
+            max_version
+        );
+    }
     None
 }
 

--- a/crates/sui-state-fetcher/src/provider.rs
+++ b/crates/sui-state-fetcher/src/provider.rs
@@ -635,6 +635,11 @@ impl HistoricalStateProvider {
         self
     }
 
+    /// Returns true if this provider is in graphql-only mode (no gRPC).
+    pub fn is_graphql_only(&self) -> bool {
+        self.graphql_only
+    }
+
     /// Enable disk caching at the specified directory.
     pub fn with_cache_dir(mut self, cache_dir: impl AsRef<Path>) -> Result<Self> {
         self.cache = Arc::new(VersionedCache::with_storage(cache_dir)?);
@@ -921,14 +926,15 @@ impl HistoricalStateProvider {
             );
         }
 
-        let allow_grpc = !matches!(
-            std::env::var("SUI_CHECKPOINT_LOOKUP_GRPC")
-                .ok()
-                .as_deref()
-                .map(|v| v.to_ascii_lowercase())
-                .as_deref(),
-            Some("0") | Some("false") | Some("no") | Some("off")
-        );
+        let allow_grpc = !self.graphql_only
+            && !matches!(
+                std::env::var("SUI_CHECKPOINT_LOOKUP_GRPC")
+                    .ok()
+                    .as_deref()
+                    .map(|v| v.to_ascii_lowercase())
+                    .as_deref(),
+                Some("0") | Some("false") | Some("no") | Some("off")
+            );
         if allow_grpc {
             match self.grpc.get_transaction(digest).await {
                 Ok(Some(tx)) => {
@@ -1060,25 +1066,29 @@ impl HistoricalStateProvider {
                 other => {
                     // Log the gRPC failure
                     match &other {
-                        Ok(None) => debug!(digest = digest, "gRPC returned no transaction, trying GraphQL"),
-                        Err(e) => debug!(digest = digest, error = %e, "gRPC transaction fetch failed, trying GraphQL"),
+                        Ok(None) => debug!(
+                            digest = digest,
+                            "gRPC returned no transaction, trying GraphQL"
+                        ),
+                        Err(e) => {
+                            debug!(digest = digest, error = %e, "gRPC transaction fetch failed, trying GraphQL")
+                        }
                         _ => {}
                     }
                     // Fall back to GraphQL
-                    let gql_tx = self
-                        .graphql
-                        .fetch_transaction(digest)
-                        .map_err(|gql_err| {
-                            let grpc_msg = match other {
-                                Ok(None) => "not found".to_string(),
-                                Err(e) => format!("{}", e),
-                                _ => "unknown".to_string(),
-                            };
-                            anyhow!(
-                                "Transaction {} not available via gRPC ({}) or GraphQL ({})",
-                                digest, grpc_msg, gql_err
-                            )
-                        })?;
+                    let gql_tx = self.graphql.fetch_transaction(digest).map_err(|gql_err| {
+                        let grpc_msg = match other {
+                            Ok(None) => "not found".to_string(),
+                            Err(e) => format!("{}", e),
+                            _ => "unknown".to_string(),
+                        };
+                        anyhow!(
+                            "Transaction {} not available via gRPC ({}) or GraphQL ({})",
+                            digest,
+                            grpc_msg,
+                            gql_err
+                        )
+                    })?;
                     debug!(
                         digest = digest,
                         elapsed_ms = tx_start.elapsed().as_millis(),
@@ -1216,6 +1226,12 @@ impl HistoricalStateProvider {
                 unchanged_loaded_runtime_objects.len(),
                 unchanged_consensus_objects.len()
             );
+            for (id, ver) in &unchanged_loaded_runtime_objects {
+                eprintln!("[runtime_objects]   ulro {} = {}", id, ver);
+            }
+            for (id, ver) in &unchanged_consensus_objects {
+                eprintln!("[runtime_objects]   uco {} = {}", id, ver);
+            }
         }
 
         if let Ok(target_id) = std::env::var("SUI_CHECK_OBJECT_ID") {
@@ -1356,6 +1372,15 @@ impl HistoricalStateProvider {
         for (id_str, version) in &unchanged_consensus_objects {
             let normalized = normalize_address(id_str);
             historical_versions.insert(normalized, *version);
+        }
+
+        if std::env::var("SUI_DUMP_RUNTIME_OBJECTS").ok().as_deref() == Some("1") {
+            let mut sorted: Vec<_> = historical_versions.iter().collect();
+            sorted.sort_by_key(|(k, _)| k.as_str());
+            eprintln!("[hist_versions] digest={} count={}", digest, sorted.len());
+            for (id, ver) in &sorted {
+                eprintln!("[hist_versions]   {} = {}", id, ver);
+            }
         }
 
         // 2b. Opportunistic Walrus checkpoint ingest (input/output objects)
@@ -1526,6 +1551,23 @@ impl HistoricalStateProvider {
         // 5. Fetch objects (cache-first, then gRPC), skipping those we already prefetched
         let obj_start = std::time::Instant::now();
         let mut objects = self.fetch_objects_versioned(&object_requests).await?;
+        if std::env::var("SUI_DUMP_RUNTIME_OBJECTS").ok().as_deref() == Some("1") {
+            use std::hash::{Hash, Hasher};
+            let mut sorted: Vec<_> = objects.iter().collect();
+            sorted.sort_by_key(|(k, _)| k.to_hex_literal());
+            for (id, obj) in &sorted {
+                let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                obj.bcs_bytes.hash(&mut hasher);
+                let bcs_hash = hasher.finish();
+                eprintln!(
+                    "[obj_bcs] id={} version={} bcs_len={} bcs_hash={:016x}",
+                    id.to_hex_literal(),
+                    obj.version,
+                    obj.bcs_bytes.len(),
+                    bcs_hash,
+                );
+            }
+        }
         debug!(
             digest = digest,
             elapsed_ms = obj_start.elapsed().as_millis(),
@@ -2011,8 +2053,7 @@ impl HistoricalStateProvider {
                                 continue;
                             }
                         } else if !self.graphql_only {
-                            if let Ok(Some(obj)) = self.grpc.get_object(&child_normalized).await
-                            {
+                            if let Ok(Some(obj)) = self.grpc.get_object(&child_normalized).await {
                                 if snapshot_used || obj.version <= max_lamport_version {
                                     Some(obj.version)
                                 } else {
@@ -2405,7 +2446,17 @@ impl HistoricalStateProvider {
                                     move || {
                                         graphql
                                             .fetch_object_at_version(&id_for_fetch, version)
-                                            .or_else(|_| graphql.fetch_object(&id_for_fetch))
+                                            .or_else(|_| {
+                                                // Historical version may be pruned from the
+                                                // direct object(address, version) index.
+                                                // Use objectVersionsBefore to find the closest
+                                                // version at or before the requested one, which
+                                                // is far safer than fetching the latest version.
+                                                graphql.fetch_object_version_before(
+                                                    &id_for_fetch,
+                                                    version + 1,
+                                                )
+                                            })
                                     }
                                 })
                                 .await;
@@ -2413,6 +2464,12 @@ impl HistoricalStateProvider {
 
                                 match gql_result {
                                     Ok(Ok(gql_obj)) => {
+                                        if gql_obj.version != version && data_gap_debug_enabled() {
+                                            eprintln!(
+                                                "[data_gap] version_mismatch obj={} requested={} got={}",
+                                                id_str, version, gql_obj.version
+                                            );
+                                        }
                                         // Extract owner info before fields are moved
                                         let (is_shared, is_immutable) = match &gql_obj.owner {
                                             ObjectOwner::Shared { .. } => (true, false),
@@ -2996,7 +3053,11 @@ impl HistoricalStateProvider {
 
         let pkg_id_str = format!("0x{}", hex::encode(pkg_id.as_ref()));
         let mut gql_pkg: Option<GraphQLPackage> = None;
-        if version_hint.is_none() {
+        // In graphql_only mode, always fetch from GraphQL (even when version_hint
+        // is known) because we need linkage data for dependency walking.
+        // In hybrid mode, only fetch from GraphQL when version_hint is unknown.
+        let should_fetch_gql = version_hint.is_none() || self.graphql_only;
+        if should_fetch_gql {
             if let Some(cp) = checkpoint {
                 if allow_package_graphql {
                     let gql_start = std::time::Instant::now();
@@ -3027,7 +3088,9 @@ impl HistoricalStateProvider {
         }
 
         let grpc_start = std::time::Instant::now();
-        let grpc_result = if let Some(ver) = version_hint {
+        let grpc_result = if self.graphql_only {
+            Ok(None) // Skip gRPC in graphql_only mode
+        } else if let Some(ver) = version_hint {
             self.grpc
                 .get_object_at_version(&pkg_id_str, Some(ver))
                 .await
@@ -3250,7 +3313,7 @@ impl HistoricalStateProvider {
                     }
                     return Ok(package_success_outcome(pkg_id, pkg_data, stats));
                 }
-                if !strict_checkpoint && version_hint.is_some() {
+                if !self.graphql_only && !strict_checkpoint && version_hint.is_some() {
                     let grpc_start = std::time::Instant::now();
                     let grpc_latest = self.grpc.get_object(&pkg_id_str).await;
                     stats.grpc_elapsed += grpc_start.elapsed().as_millis();
@@ -3279,7 +3342,7 @@ impl HistoricalStateProvider {
                     }
                     return Ok(package_success_outcome(pkg_id, pkg_data, stats));
                 }
-                if !strict_checkpoint && version_hint.is_some() {
+                if !self.graphql_only && !strict_checkpoint && version_hint.is_some() {
                     let grpc_start = std::time::Instant::now();
                     let grpc_latest = self.grpc.get_object(&pkg_id_str).await;
                     stats.grpc_elapsed += grpc_start.elapsed().as_millis();
@@ -3641,6 +3704,7 @@ fn ingest_walrus_objects(
 ) -> usize {
     let mut ingested = 0usize;
     for key in ["input_objects", "output_objects"] {
+        let is_input = key == "input_objects";
         let Some(arr) = tx_json.get(key).and_then(|v| v.as_array()) else {
             continue;
         };
@@ -3664,9 +3728,12 @@ fn ingest_walrus_objects(
                             prev_tx.clone(),
                         );
                     }
-                    if let Some(historical_versions) = historical_versions.as_deref_mut() {
-                        let pkg_str = format!("0x{}", hex::encode(pkg_data.address.as_ref()));
-                        historical_versions.insert(normalize_address(&pkg_str), pkg_data.version);
+                    if is_input {
+                        if let Some(historical_versions) = historical_versions.as_deref_mut() {
+                            let pkg_str = format!("0x{}", hex::encode(pkg_data.address.as_ref()));
+                            historical_versions
+                                .insert(normalize_address(&pkg_str), pkg_data.version);
+                        }
                     }
                     if cache.is_some() {
                         ingested += 1;
@@ -3717,8 +3784,10 @@ fn ingest_walrus_objects(
                     is_immutable,
                 });
             }
-            if let Some(historical_versions) = historical_versions.as_deref_mut() {
-                historical_versions.insert(normalize_address(&id.to_hex_literal()), version);
+            if is_input {
+                if let Some(historical_versions) = historical_versions.as_deref_mut() {
+                    historical_versions.insert(normalize_address(&id.to_hex_literal()), version);
+                }
             }
             if let Some(store) = store {
                 if let Some(type_tag) = type_tag.clone() {
@@ -4037,27 +4106,21 @@ fn graphql_package_to_data(pkg_id: AccountAddress, pkg: GraphQLPackage) -> Resul
         }
     }
 
-    // Derive original_id from typeOrigins: if any type's definingId differs
-    // from this package's address, that definingId is the original package.
-    let original_id = pkg
-        .type_origins
-        .iter()
-        .find_map(|origin| {
-            let defining = parse_object_id(&origin.defining_id).ok()?;
-            if defining != pkg_id {
-                Some(defining)
-            } else {
-                None
-            }
-        })
-        .or_else(|| {
-            // All typeOrigins point to this address — this IS the original package.
-            if !pkg.type_origins.is_empty() {
-                Some(pkg_id)
-            } else {
-                None
-            }
-        });
+    // Derive original_id from module bytecode self_id — this is the most reliable
+    // source since the bytecode embeds the true original/runtime package address.
+    // Using typeOrigins is unreliable because for packages with complex upgrade
+    // chains, the first non-self definingId may be an intermediate upgrade address
+    // rather than the true original.
+    let original_id = if !modules.is_empty() {
+        use move_binary_format::CompiledModule;
+        CompiledModule::deserialize_with_defaults(&modules[0].1)
+            .ok()
+            .map(|m| *m.self_id().address())
+    } else if !pkg.type_origins.is_empty() {
+        Some(pkg_id)
+    } else {
+        None
+    };
 
     Ok(PackageData {
         address: pkg_id,
@@ -4089,6 +4152,22 @@ fn graphql_arg_to_grpc(arg: &sui_transport::graphql::GraphQLArgument) -> GrpcArg
 /// are left empty — they will be filled by other mechanisms (object fetching, dynamic
 /// field prefetching).
 fn graphql_tx_to_grpc_tx(gql: &GraphQLTransaction) -> GrpcTransaction {
+    let debug = std::env::var("SUI_DEBUG_DF_FETCH").is_ok();
+    if debug {
+        eprintln!(
+            "[graphql_tx_to_grpc_tx] inputs={} commands={} digest={}",
+            gql.inputs.len(),
+            gql.commands.len(),
+            gql.digest,
+        );
+        for (i, cmd) in gql.commands.iter().enumerate() {
+            eprintln!(
+                "[graphql_tx_to_grpc_tx]   cmd[{}] = {:?}",
+                i,
+                std::mem::discriminant(cmd)
+            );
+        }
+    }
     // Convert inputs
     let inputs: Vec<GrpcInput> = gql
         .inputs
@@ -4165,23 +4244,17 @@ fn graphql_tx_to_grpc_tx(gql: &GraphQLTransaction) -> GrpcTransaction {
                     address: graphql_arg_to_grpc(address),
                 })
             }
-            GraphQLCommand::MakeMoveVec { type_arg, elements } => {
-                Some(GrpcCommand::MakeMoveVec {
-                    element_type: type_arg.clone(),
-                    elements: elements.iter().map(graphql_arg_to_grpc).collect(),
-                })
-            }
+            GraphQLCommand::MakeMoveVec { type_arg, elements } => Some(GrpcCommand::MakeMoveVec {
+                element_type: type_arg.clone(),
+                elements: elements.iter().map(graphql_arg_to_grpc).collect(),
+            }),
             GraphQLCommand::Publish {
                 modules,
                 dependencies,
             } => Some(GrpcCommand::Publish {
                 modules: modules
                     .iter()
-                    .filter_map(|m| {
-                        base64::engine::general_purpose::STANDARD
-                            .decode(m)
-                            .ok()
-                    })
+                    .filter_map(|m| base64::engine::general_purpose::STANDARD.decode(m).ok())
                     .collect(),
                 dependencies: dependencies.clone(),
             }),
@@ -4193,19 +4266,54 @@ fn graphql_tx_to_grpc_tx(gql: &GraphQLTransaction) -> GrpcTransaction {
             } => Some(GrpcCommand::Upgrade {
                 modules: modules
                     .iter()
-                    .filter_map(|m| {
-                        base64::engine::general_purpose::STANDARD
-                            .decode(m)
-                            .ok()
-                    })
+                    .filter_map(|m| base64::engine::general_purpose::STANDARD.decode(m).ok())
                     .collect(),
                 dependencies: dependencies.clone(),
                 package: package.clone(),
                 ticket: graphql_arg_to_grpc(ticket),
             }),
-            GraphQLCommand::Other { .. } => None,
+            GraphQLCommand::Other { typename } => {
+                if debug {
+                    eprintln!(
+                        "[graphql_tx_to_grpc_tx] DROPPING command with typename={}",
+                        typename
+                    );
+                }
+                None
+            }
         })
         .collect();
+
+    if debug {
+        eprintln!(
+            "[graphql_tx_to_grpc_tx] converted {} grpc commands, {} inputs",
+            commands.len(),
+            inputs.len(),
+        );
+        for (i, cmd) in commands.iter().enumerate() {
+            let desc = match cmd {
+                GrpcCommand::MoveCall {
+                    package,
+                    module,
+                    function,
+                    ..
+                } => {
+                    format!("MoveCall {}::{}::{}", package, module, function)
+                }
+                GrpcCommand::SplitCoins { coin, amounts } => {
+                    format!("SplitCoins coin={:?} amounts={}", coin, amounts.len())
+                }
+                GrpcCommand::MergeCoins { coin, sources } => {
+                    format!("MergeCoins coin={:?} sources={}", coin, sources.len())
+                }
+                GrpcCommand::TransferObjects { objects, address } => {
+                    format!("TransferObjects objs={} addr={:?}", objects.len(), address)
+                }
+                _ => format!("{:?}", std::mem::discriminant(cmd)),
+            };
+            eprintln!("[graphql_tx_to_grpc_tx]   grpc_cmd[{}] = {}", i, desc);
+        }
+    }
 
     // Build changed_objects from effects (mutated objects with input versions)
     let mut changed_objects = Vec::new();

--- a/crates/sui-transport/src/graphql.rs
+++ b/crates/sui-transport/src/graphql.rs
@@ -59,6 +59,7 @@ pub struct GraphQLClient {
     endpoint: String,
     agent: ureq::Agent,
     circuit_state: Arc<GraphQLCircuitState>,
+    request_count: Arc<AtomicU64>,
 }
 
 #[derive(Debug, Default)]
@@ -701,11 +702,18 @@ impl GraphQLClient {
             endpoint: endpoint.to_string(),
             agent: Self::build_agent(timeout, connect_timeout),
             circuit_state: Arc::new(GraphQLCircuitState::default()),
+            request_count: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Total number of GraphQL HTTP requests made through this client.
+    pub fn request_count(&self) -> u64 {
+        self.request_count.load(Ordering::Relaxed)
     }
 
     /// Execute a GraphQL query.
     fn query(&self, query: &str, variables: Option<Value>) -> Result<Value> {
+        self.request_count.fetch_add(1, Ordering::Relaxed);
         if Self::circuit_breaker_enabled() {
             if let Some(remaining_ms) = self.circuit_open_remaining_ms() {
                 return Err(anyhow!(
@@ -953,9 +961,9 @@ impl GraphQLClient {
         address: &str,
         checkpoint: u64,
     ) -> Result<GraphQLObject> {
-        let snapshot_query = r#"
+        let query = r#"
             query GetObjectAtCheckpoint($address: SuiAddress!, $checkpoint: UInt53!) {
-                object(address: $address, version: null) @snapshot(at: $checkpoint) {
+                object(address: $address, atCheckpoint: $checkpoint) {
                     address
                     version
                     digest
@@ -988,7 +996,7 @@ impl GraphQLClient {
             "checkpoint": checkpoint
         });
 
-        let data = self.query(snapshot_query, Some(variables))?;
+        let data = self.query(query, Some(variables))?;
 
         let obj = data
             .get("object")
@@ -1001,6 +1009,117 @@ impl GraphQLClient {
                 address
             ));
         }
+
+        let owner = self.parse_owner(obj.get("owner"));
+        let move_obj = obj.get("asMoveObject").and_then(|m| m.get("contents"));
+        let type_string = move_obj
+            .and_then(|c| c.get("type"))
+            .and_then(|t| t.get("repr"))
+            .and_then(|r| r.as_str())
+            .map(|s| s.to_string());
+        let bcs_base64 = move_obj
+            .and_then(|c| c.get("bcs"))
+            .and_then(|b| b.as_str())
+            .map(|s| s.to_string());
+        let content_json = move_obj.and_then(|c| c.get("json")).cloned();
+
+        Ok(GraphQLObject {
+            address: obj
+                .get("address")
+                .and_then(|a| a.as_str())
+                .unwrap_or(address)
+                .to_string(),
+            version: obj.get("version").and_then(|v| v.as_u64()).unwrap_or(1),
+            digest: obj
+                .get("digest")
+                .and_then(|d| d.as_str())
+                .map(|s| s.to_string()),
+            type_string,
+            owner,
+            bcs_base64,
+            content_json,
+            previous_transaction: obj
+                .get("previousTransaction")
+                .and_then(|p| p.get("digest"))
+                .and_then(|d| d.as_str())
+                .map(|s| s.to_string()),
+        })
+    }
+
+    /// Fetch the most recent version of an object at or before a given version.
+    ///
+    /// Uses the `objectVersionsBefore` query to find historical object state.
+    /// This is useful as a fallback when `@snapshot` is not supported.
+    pub fn fetch_object_version_before(
+        &self,
+        address: &str,
+        before_version: u64,
+    ) -> Result<GraphQLObject> {
+        // Use top-level objectVersions query instead of nesting under object().
+        // The nested approach fails for deleted/wrapped objects because
+        // object(address: ...) returns null, making the nested query unreachable.
+        let query = r#"
+            query GetObjectVersionBefore($address: SuiAddress!, $beforeVersion: UInt53!) {
+                objectVersions(
+                    address: $address,
+                    last: 1,
+                    filter: { beforeVersion: $beforeVersion }
+                ) {
+                    nodes {
+                        address
+                        version
+                        digest
+                        previousTransaction { digest }
+                        owner {
+                            __typename
+                            ... on AddressOwner {
+                                address { address }
+                            }
+                            ... on Shared {
+                                initialSharedVersion
+                            }
+                            ... on ObjectOwner {
+                                address { address }
+                            }
+                        }
+                        asMoveObject {
+                            contents {
+                                type { repr }
+                                bcs
+                                json
+                            }
+                        }
+                    }
+                }
+            }
+        "#;
+
+        let variables = serde_json::json!({
+            "address": address,
+            "beforeVersion": before_version
+        });
+
+        let data = self.query(query, Some(variables))?;
+
+        let nodes = data
+            .get("objectVersions")
+            .and_then(|v| v.get("nodes"))
+            .and_then(|n| n.as_array())
+            .ok_or_else(|| {
+                anyhow!(
+                    "No version found before {} for object {}",
+                    before_version,
+                    address
+                )
+            })?;
+
+        let obj = nodes.first().ok_or_else(|| {
+            anyhow!(
+                "No version found before {} for object {}",
+                before_version,
+                address
+            )
+        })?;
 
         let owner = self.parse_owner(obj.get("owner"));
         let move_obj = obj.get("asMoveObject").and_then(|m| m.get("contents"));
@@ -1112,22 +1231,51 @@ impl GraphQLClient {
             if cursor.is_none() {
                 if let Some(linkage_arr) = pkg.get("linkage").and_then(|l| l.as_array()) {
                     for entry in linkage_arr {
-                        let original_id = entry.get("originalId").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                        let upgraded_id = entry.get("upgradedId").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                        let original_id = entry
+                            .get("originalId")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let upgraded_id = entry
+                            .get("upgradedId")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
                         let version = entry.get("version").and_then(|v| v.as_u64()).unwrap_or(0);
                         if !original_id.is_empty() && !upgraded_id.is_empty() {
-                            all_linkage.push(GraphQLLinkage { original_id, upgraded_id, version });
+                            all_linkage.push(GraphQLLinkage {
+                                original_id,
+                                upgraded_id,
+                                version,
+                            });
                         }
                     }
                 }
 
                 if let Some(origins_arr) = pkg.get("typeOrigins").and_then(|o| o.as_array()) {
                     for entry in origins_arr {
-                        let module = entry.get("module").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                        let struct_name = entry.get("struct").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                        let defining_id = entry.get("definingId").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                        if !module.is_empty() && !struct_name.is_empty() && !defining_id.is_empty() {
-                            all_type_origins.push(GraphQLTypeOrigin { module, struct_name, defining_id });
+                        let module = entry
+                            .get("module")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let struct_name = entry
+                            .get("struct")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let defining_id = entry
+                            .get("definingId")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if !module.is_empty() && !struct_name.is_empty() && !defining_id.is_empty()
+                        {
+                            all_type_origins.push(GraphQLTypeOrigin {
+                                module,
+                                struct_name,
+                                defining_id,
+                            });
                         }
                     }
                 }
@@ -1340,53 +1488,21 @@ impl GraphQLClient {
             let query = format!(
                 r#"
                 query GetPackageAtCheckpoint($address: SuiAddress!, $checkpoint: UInt53!) {{
-                    checkpoint(sequenceNumber: $checkpoint) {{
-                        sequenceNumber
-                    }}
-                    object(address: $address, version: null) @snapshot(at: $checkpoint) {{
+                    package(address: $address, atCheckpoint: $checkpoint) {{
                         address
                         version
-                        asMovePackage {{
-                            modules(first: 50{}) {{
-                                nodes {{
-                                    name
-                                    bytes
-                                }}
-                                pageInfo {{
-                                    hasNextPage
-                                    endCursor
-                                }}
+                        modules(first: 50{}) {{
+                            nodes {{
+                                name
+                                bytes
                             }}
-                            linkage {{ originalId upgradedId version }}
-                            typeOrigins {{ module struct definingId }}
-                        }}
-                    }}
-                }}
-                "#,
-                after_clause
-            );
-
-            // Try alternative query format if @snapshot doesn't work
-            let alt_query = format!(
-                r#"
-                query GetPackageAtCheckpoint($address: SuiAddress!) {{
-                    object(address: $address) {{
-                        address
-                        version
-                        asMovePackage {{
-                            modules(first: 50{}) {{
-                                nodes {{
-                                    name
-                                    bytes
-                                }}
-                                pageInfo {{
-                                    hasNextPage
-                                    endCursor
-                                }}
+                            pageInfo {{
+                                hasNextPage
+                                endCursor
                             }}
-                            linkage {{ originalId upgradedId version }}
-                            typeOrigins {{ module struct definingId }}
                         }}
+                        linkage {{ originalId upgradedId version }}
+                        typeOrigins {{ module struct definingId }}
                     }}
                 }}
                 "#,
@@ -1398,21 +1514,9 @@ impl GraphQLClient {
                 "checkpoint": checkpoint
             });
 
-            let data = match self.query(&query, Some(variables.clone())) {
-                Ok(d) => d,
-                Err(_) => {
-                    let simple_vars = serde_json::json!({ "address": address });
-                    match self.query(&alt_query, Some(simple_vars)) {
-                        Ok(d) => d,
-                        Err(_) => {
-                            // Fallback to latest with full pagination.
-                            return self.fetch_package(address);
-                        }
-                    }
-                }
-            };
+            let data = self.query(&query, Some(variables))?;
 
-            let obj = data.get("object").ok_or_else(|| {
+            let pkg = data.get("package").ok_or_else(|| {
                 anyhow!(
                     "Package not found at checkpoint {}: {}",
                     checkpoint,
@@ -1420,7 +1524,7 @@ impl GraphQLClient {
                 )
             })?;
 
-            if obj.is_null() {
+            if pkg.is_null() {
                 return Err(anyhow!(
                     "Package not found at checkpoint {}: {}",
                     checkpoint,
@@ -1429,38 +1533,63 @@ impl GraphQLClient {
             }
 
             if cursor.is_none() {
-                pkg_address = obj
+                pkg_address = pkg
                     .get("address")
                     .and_then(|a| a.as_str())
                     .unwrap_or(address)
                     .to_string();
-                pkg_version = obj.get("version").and_then(|v| v.as_u64()).unwrap_or(1);
+                pkg_version = pkg.get("version").and_then(|v| v.as_u64()).unwrap_or(1);
             }
-
-            let pkg = obj
-                .get("asMovePackage")
-                .ok_or_else(|| anyhow!("Object is not a package: {}", address))?;
 
             // Parse linkage and typeOrigins on first page (they are not paginated)
             if cursor.is_none() {
                 if let Some(linkage_arr) = pkg.get("linkage").and_then(|l| l.as_array()) {
                     for entry in linkage_arr {
-                        let original_id = entry.get("originalId").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                        let upgraded_id = entry.get("upgradedId").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                        let original_id = entry
+                            .get("originalId")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let upgraded_id = entry
+                            .get("upgradedId")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
                         let version = entry.get("version").and_then(|v| v.as_u64()).unwrap_or(0);
                         if !original_id.is_empty() && !upgraded_id.is_empty() {
-                            all_linkage.push(GraphQLLinkage { original_id, upgraded_id, version });
+                            all_linkage.push(GraphQLLinkage {
+                                original_id,
+                                upgraded_id,
+                                version,
+                            });
                         }
                     }
                 }
 
                 if let Some(origins_arr) = pkg.get("typeOrigins").and_then(|o| o.as_array()) {
                     for entry in origins_arr {
-                        let module = entry.get("module").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                        let struct_name = entry.get("struct").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                        let defining_id = entry.get("definingId").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                        if !module.is_empty() && !struct_name.is_empty() && !defining_id.is_empty() {
-                            all_type_origins.push(GraphQLTypeOrigin { module, struct_name, defining_id });
+                        let module = entry
+                            .get("module")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let struct_name = entry
+                            .get("struct")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let defining_id = entry
+                            .get("definingId")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if !module.is_empty() && !struct_name.is_empty() && !defining_id.is_empty()
+                        {
+                            all_type_origins.push(GraphQLTypeOrigin {
+                                module,
+                                struct_name,
+                                defining_id,
+                            });
                         }
                     }
                 }
@@ -1524,11 +1653,8 @@ impl GraphQLClient {
     ) -> Result<Option<u64>> {
         let query = r#"
             query GetPackageVersionAtCheckpoint($address: SuiAddress!, $checkpoint: UInt53!) {
-                object(address: $address, version: null) @snapshot(at: $checkpoint) {
+                package(address: $address, atCheckpoint: $checkpoint) {
                     version
-                    asMovePackage {
-                        address
-                    }
                 }
             }
         "#;
@@ -1539,17 +1665,14 @@ impl GraphQLClient {
         });
 
         let data = self.query(query, Some(variables))?;
-        let obj = match data.get("object") {
+        let pkg = match data.get("package") {
             Some(v) => v,
             None => return Ok(None),
         };
-        if obj.is_null() {
+        if pkg.is_null() {
             return Ok(None);
         }
-        if obj.get("asMovePackage").is_none() {
-            return Ok(None);
-        }
-        Ok(obj.get("version").and_then(|v| v.as_u64()))
+        Ok(pkg.get("version").and_then(|v| v.as_u64()))
     }
 
     /// Fetch a transaction by digest with full PTB details.
@@ -1896,12 +2019,13 @@ impl GraphQLClient {
                         .unwrap_or_default();
                     commands.push(GraphQLCommand::SplitCoins { coin, amounts });
                 } else if let Some(mc) = node.get("mergeCoins") {
+                    // transactionJson uses "coin" for destination and "coinsToMerge" for sources
                     let destination = mc
-                        .get("destination")
+                        .get("coin")
                         .map(|c| self.parse_json_argument(c))
                         .unwrap_or(GraphQLArgument::GasCoin);
                     let sources: Vec<GraphQLArgument> = mc
-                        .get("sources")
+                        .get("coinsToMerge")
                         .and_then(|s| s.as_array())
                         .map(|arr| arr.iter().map(|a| self.parse_json_argument(a)).collect())
                         .unwrap_or_default();
@@ -1996,6 +2120,8 @@ impl GraphQLClient {
     }
 
     /// Parse argument from transactionJson format.
+    /// transactionJson uses: "kind"="INPUT"/"RESULT"/"GAS_COIN",
+    /// "input" for input index, "result" for command index, "subresult" for nested result index.
     fn parse_json_argument(&self, arg: &Value) -> GraphQLArgument {
         let kind = arg.get("kind").and_then(|k| k.as_str()).unwrap_or("");
         match kind {
@@ -2005,12 +2131,34 @@ impl GraphQLClient {
                 GraphQLArgument::Input(index)
             }
             "RESULT" => {
-                let index = arg.get("cmd").and_then(|c| c.as_u64()).unwrap_or(0) as u16;
-                GraphQLArgument::Result(index)
+                // transactionJson uses "result" for command index and optional "subresult"
+                let cmd = arg
+                    .get("result")
+                    .or_else(|| arg.get("cmd"))
+                    .and_then(|c| c.as_u64())
+                    .unwrap_or(0) as u16;
+                if let Some(sub) = arg
+                    .get("subresult")
+                    .or_else(|| arg.get("ix"))
+                    .and_then(|s| s.as_u64())
+                {
+                    GraphQLArgument::NestedResult(cmd, sub as u16)
+                } else {
+                    GraphQLArgument::Result(cmd)
+                }
             }
             "NESTED_RESULT" => {
-                let cmd = arg.get("cmd").and_then(|c| c.as_u64()).unwrap_or(0) as u16;
-                let result_idx = arg.get("ix").and_then(|i| i.as_u64()).unwrap_or(0) as u16;
+                // Legacy format support
+                let cmd = arg
+                    .get("cmd")
+                    .or_else(|| arg.get("result"))
+                    .and_then(|c| c.as_u64())
+                    .unwrap_or(0) as u16;
+                let result_idx = arg
+                    .get("ix")
+                    .or_else(|| arg.get("subresult"))
+                    .and_then(|i| i.as_u64())
+                    .unwrap_or(0) as u16;
                 GraphQLArgument::NestedResult(cmd, result_idx)
             }
             _ => GraphQLArgument::GasCoin,
@@ -2438,10 +2586,7 @@ impl GraphQLClient {
                         .and_then(|a| a.as_str())
                         .unwrap_or("")
                         .to_string();
-                    let version = obj
-                        .get("version")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0);
+                    let version = obj.get("version").and_then(|v| v.as_u64()).unwrap_or(0);
                     if !addr.is_empty() && version > 0 {
                         unchanged_consensus_objects.push((addr, version));
                     }
@@ -2471,7 +2616,10 @@ impl GraphQLClient {
                     Some(ej_raw.clone())
                 };
                 if let Some(ej) = ej {
-                    if let Some(items) = ej.get("unchangedConsensusObjects").and_then(|v| v.as_array()) {
+                    if let Some(items) = ej
+                        .get("unchangedConsensusObjects")
+                        .and_then(|v| v.as_array())
+                    {
                         for item in items {
                             let addr = item
                                 .get("objectId")
@@ -2992,7 +3140,6 @@ impl GraphQLClient {
     }
 
     /// Fetch a dynamic field by name at a specific checkpoint (for historical replay).
-    /// Falls back to the latest state if snapshot queries are unsupported.
     pub fn fetch_dynamic_field_by_name_at_checkpoint(
         &self,
         parent_address: &str,
@@ -3009,7 +3156,7 @@ impl GraphQLClient {
                 $nameType: String!,
                 $nameBcs: Base64!
             ) {
-                object(address: $address, version: null) @snapshot(at: $checkpoint) {
+                object(address: $address, atCheckpoint: $checkpoint) {
                     dynamicField(name: { type: $nameType, bcs: $nameBcs }) {
                         name {
                             type { repr }
@@ -3046,12 +3193,7 @@ impl GraphQLClient {
             "nameBcs": name_bcs_b64,
         });
 
-        let data = match self.query(query, Some(variables)) {
-            Ok(data) => data,
-            Err(_) => {
-                return self.fetch_dynamic_field_by_name(parent_address, name_type, name_bcs);
-            }
-        };
+        let data = self.query(query, Some(variables))?;
         let node = data
             .get("object")
             .and_then(|o| o.get("dynamicField"))
@@ -3208,7 +3350,7 @@ impl GraphQLClient {
                 $after: String,
                 $checkpoint: UInt53!
             ) {
-                object(address: $address, version: null) @snapshot(at: $checkpoint) {
+                object(address: $address, atCheckpoint: $checkpoint) {
                     dynamicFields(first: $limit, after: $after) {
                         pageInfo {
                             hasNextPage

--- a/crates/sui-transport/src/grpc/client.rs
+++ b/crates/sui-transport/src/grpc/client.rs
@@ -9,6 +9,8 @@
 
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use tonic::transport::Channel;
 
 use super::generated::sui_rpc_v2::{
@@ -31,6 +33,7 @@ pub struct GrpcClient {
     endpoint: String,
     channel: Channel,
     api_key: Option<String>,
+    request_count: Arc<AtomicU64>,
 }
 
 const MAINNET_ENDPOINT: &str = "https://archive.mainnet.sui.io:443";
@@ -181,6 +184,7 @@ impl GrpcClient {
             endpoint: endpoint.to_string(),
             channel,
             api_key,
+            request_count: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -211,11 +215,18 @@ impl GrpcClient {
             endpoint: endpoint.to_string(),
             channel,
             api_key,
+            request_count: Arc::new(AtomicU64::new(0)),
         })
+    }
+
+    /// Total number of gRPC requests made through this client.
+    pub fn request_count(&self) -> u64 {
+        self.request_count.load(Ordering::Relaxed)
     }
 
     /// Wrap a request with the API key header if configured.
     fn wrap_request<T>(&self, req: T) -> tonic::Request<T> {
+        self.request_count.fetch_add(1, Ordering::Relaxed);
         let mut request = tonic::Request::new(req);
         if let Some(ref key) = self.api_key {
             if let Ok(value) = key.parse() {
@@ -423,6 +434,7 @@ impl GrpcClient {
             endpoint: self.endpoint.clone(),
             channel: self.channel.clone(),
             api_key: self.api_key.clone(),
+            request_count: self.request_count.clone(),
         }
     }
 

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -61,7 +61,11 @@ def main() -> int:
 
     # Ignore generated/build artifacts and vendored docs.
     ignored = {base / ".git", base / "target", base / ".venv"}
-    md_files = [p for p in md_files if not any(parent in ignored for parent in p.parents)]
+    md_files = [
+        p
+        for p in md_files
+        if not any(parent in ignored or parent.name == "node_modules" for parent in p.parents)
+    ]
 
     missing = []
     for md in md_files:

--- a/src/bin/sandbox_cli/analyze/mm2_common.rs
+++ b/src/bin/sandbox_cli/analyze/mm2_common.rs
@@ -315,7 +315,7 @@ pub(super) fn build_mm2_summary(
     #[cfg(feature = "mm2")]
     {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            sui_sandbox_core::mm2::TypeModel::from_modules(modules)
+            sui_sandbox_core::mm2::TypeModel::from_modules(modules).map_err(Box::new)
         }));
         match result {
             Ok(Ok(_)) => (Some(true), None),

--- a/src/bin/sandbox_cli/flow.rs
+++ b/src/bin/sandbox_cli/flow.rs
@@ -349,6 +349,7 @@ impl ReplayExecutionArgs {
             state_json,
             export_state: None,
             latest: None,
+            compare_sources: false,
         }
     }
 }

--- a/src/bin/sandbox_cli/replay.rs
+++ b/src/bin/sandbox_cli/replay.rs
@@ -35,6 +35,7 @@ use sui_types::effects::TransactionEffectsAPI;
 
 mod analysis;
 mod batch;
+mod compare;
 mod deps;
 mod dynamic_fields;
 mod effects;
@@ -127,6 +128,10 @@ pub struct ReplayCmd {
     #[arg(long)]
     pub compare: bool,
 
+    /// Run GraphQL-only and hybrid replays concurrently and compare results
+    #[arg(long, default_value_t = false)]
+    pub compare_sources: bool,
+
     /// Hydration-only mode (skip VM execution and return replay state summary)
     #[arg(long, alias = "hydrate-only", default_value_t = false)]
     pub analyze_only: bool,
@@ -192,6 +197,8 @@ pub struct ReplayOutput {
     #[serde(skip)]
     pub effects_full: Option<sui_sandbox_core::ptb::TransactionEffects>,
     pub commands_executed: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_comparison: Option<SourceComparisonResult>,
     /// When true, the batch summary was already printed; skip individual output.
     #[serde(skip)]
     pub batch_summary_printed: bool,
@@ -213,6 +220,8 @@ pub struct ReplayExecutionPath {
     pub dependency_fetch_mode: String,
     pub dependency_packages_fetched: usize,
     pub synthetic_inputs: usize,
+    pub graphql_requests: u64,
+    pub grpc_requests: u64,
 }
 
 #[derive(Debug, Serialize)]
@@ -255,6 +264,31 @@ pub struct ComparisonResult {
     pub local_status: String,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub notes: Vec<String>,
+}
+
+/// Result of running GraphQL-only vs hybrid concurrently on the same transaction.
+#[derive(Debug, Serialize)]
+pub struct SourceComparisonResult {
+    pub graphql_success: bool,
+    pub hybrid_success: bool,
+    pub results_match: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub graphql_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hybrid_error: Option<String>,
+    pub graphql_api_calls: SourceApiCalls,
+    pub hybrid_api_calls: SourceApiCalls,
+    pub graphql_duration_ms: u128,
+    pub hybrid_duration_ms: u128,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub notes: Vec<String>,
+}
+
+/// API call counts for a single replay run.
+#[derive(Debug, Serialize)]
+pub struct SourceApiCalls {
+    pub graphql: u64,
+    pub grpc: u64,
 }
 
 /// Shared object cache for batch replay: id_hex → (type_str, bcs_bytes, version)
@@ -591,6 +625,11 @@ impl ReplayCmd {
 
         if verbose {
             eprintln!("Fetching transaction {}...", self.digest_display());
+        }
+
+        // Concurrent source comparison mode: run GraphQL-only and hybrid side-by-side
+        if self.compare_sources {
+            return self.execute_compare_sources(state, verbose).await;
         }
 
         // JSON state path: --state-json provided, load from file (no network)
@@ -1061,6 +1100,8 @@ impl ReplayCmd {
             }
         }
 
+        let graphql_requests = provider.graphql().request_count();
+        let grpc_requests = provider.grpc().request_count();
         let execution_path = build_execution_path(
             self,
             allow_fallback,
@@ -1070,6 +1111,8 @@ impl ReplayCmd {
             fallback_used,
             fallback_reasons,
             synthetic_logs.len(),
+            graphql_requests,
+            grpc_requests,
         );
 
         match replay_result {
@@ -1133,6 +1176,7 @@ impl ReplayCmd {
                     effects: Some(effects_summary),
                     effects_full: Some(execution.effects),
                     commands_executed: result.commands_executed,
+                    source_comparison: None,
                     batch_summary_printed: false,
                 })
             }
@@ -1154,6 +1198,7 @@ impl ReplayCmd {
                     effects: None,
                     effects_full: None,
                     commands_executed: 0,
+                    source_comparison: None,
                     batch_summary_printed: false,
                 })
             }
@@ -2128,12 +2173,14 @@ impl ReplayCmd {
                         dependency_fetch_mode: "walrus_checkpoint".to_string(),
                         dependency_packages_fetched,
                         synthetic_inputs: 0,
+                        ..Default::default()
                     },
                     comparison,
                     analysis: None,
                     effects: Some(effects_summary),
                     effects_full: Some(execution.effects),
                     commands_executed: result.commands_executed,
+                    source_comparison: None,
                     batch_summary_printed: false,
                 })
             }
@@ -2167,12 +2214,14 @@ impl ReplayCmd {
                         dependency_fetch_mode: "walrus_checkpoint".to_string(),
                         dependency_packages_fetched,
                         synthetic_inputs: 0,
+                        ..Default::default()
                     },
                     comparison: None,
                     analysis: None,
                     effects: None,
                     effects_full: None,
                     commands_executed: 0,
+                    source_comparison: None,
                     batch_summary_printed: false,
                 })
             }
@@ -2256,6 +2305,7 @@ mod tests {
             effects: None,
             effects_full: None,
             commands_executed: 3,
+            source_comparison: None,
             batch_summary_printed: false,
         };
 

--- a/src/bin/sandbox_cli/replay/analysis.rs
+++ b/src/bin/sandbox_cli/replay/analysis.rs
@@ -50,12 +50,14 @@ pub(super) fn build_analyze_replay_output(
             dependency_fetch_mode: "hydration_only".to_string(),
             dependency_packages_fetched: 0,
             synthetic_inputs: 0,
+            ..Default::default()
         },
         comparison: None,
         analysis: Some(analysis),
         effects: None,
         effects_full: None,
         commands_executed: 0,
+        source_comparison: None,
         batch_summary_printed: false,
     }
 }

--- a/src/bin/sandbox_cli/replay/compare.rs
+++ b/src/bin/sandbox_cli/replay/compare.rs
@@ -1,0 +1,366 @@
+use anyhow::Result;
+use std::sync::Arc;
+use std::time::Instant;
+
+use sui_sandbox_core::tx_replay::{self, EffectsReconcilePolicy};
+use sui_state_fetcher::{
+    build_aliases as build_aliases_shared, fetch_child_object, HistoricalStateProvider,
+};
+
+use super::super::SandboxState;
+use super::deps::fetch_dependency_closure;
+use super::effects::build_effects_summary;
+use super::hydration::{
+    build_historical_state_provider, build_replay_state, ReplayHydrationConfig,
+};
+use super::support::{
+    build_replay_object_maps, build_simulation_config, emit_linkage_debug_info,
+    hydrate_resolver_from_replay_state, maybe_patch_replay_objects,
+};
+use super::{
+    ComparisonResult, FetchStrategy, ReplayCmd, ReplayExecutionPath, ReplayOutput, ReplaySource,
+    SourceApiCalls, SourceComparisonResult,
+};
+
+/// Lightweight result from a single-source replay pipeline.
+struct SingleSourceResult {
+    output: ReplayOutput,
+    graphql_requests: u64,
+    grpc_requests: u64,
+    duration: std::time::Duration,
+}
+
+impl ReplayCmd {
+    /// Run GraphQL-only and hybrid replays, compare results side-by-side.
+    pub(super) async fn execute_compare_sources(
+        &self,
+        state: &SandboxState,
+        _verbose: bool,
+    ) -> Result<ReplayOutput> {
+        let allow_fallback = self.hydration.allow_fallback && !self.vm_only;
+        let digest = self.digest_required()?;
+
+        eprintln!("[compare] building providers for graphql and hybrid...");
+
+        // Build both providers concurrently
+        let (gql_provider, hyb_provider) = tokio::try_join!(
+            build_historical_state_provider(state, ReplaySource::Graphql, allow_fallback, false),
+            build_historical_state_provider(state, ReplaySource::Hybrid, allow_fallback, false),
+        )?;
+
+        let enable_dynamic_fields =
+            !self.hydration.no_prefetch && self.fetch_strategy == FetchStrategy::Full;
+        let hydration_config = ReplayHydrationConfig {
+            prefetch_dynamic_fields: enable_dynamic_fields,
+            prefetch_depth: self.hydration.prefetch_depth,
+            prefetch_limit: self.hydration.prefetch_limit,
+            auto_system_objects: self.hydration.auto_system_objects,
+        };
+
+        eprintln!("[compare] fetching replay state from both sources...");
+
+        // Fetch replay states concurrently (this is where most API calls happen)
+        let (gql_state_result, hyb_state_result) = tokio::join!(
+            build_replay_state(gql_provider.as_ref(), digest, hydration_config),
+            build_replay_state(hyb_provider.as_ref(), digest, hydration_config),
+        );
+
+        // Run each pipeline sequentially (VM execution is fast)
+        eprintln!("[compare] running graphql pipeline...");
+        let gql_result = run_pipeline(
+            self,
+            state,
+            &gql_provider,
+            gql_state_result,
+            "graphql",
+            allow_fallback,
+            enable_dynamic_fields,
+        );
+
+        eprintln!("[compare] running hybrid pipeline...");
+        let hyb_result = run_pipeline(
+            self,
+            state,
+            &hyb_provider,
+            hyb_state_result,
+            "hybrid",
+            allow_fallback,
+            enable_dynamic_fields,
+        );
+
+        // Build comparison
+        let gql = gql_result;
+        let hyb = hyb_result;
+
+        let results_match = match (&gql, &hyb) {
+            (Ok(g), Ok(h)) => {
+                g.output.local_success == h.output.local_success
+                    && g.output.local_error == h.output.local_error
+                    && g.output.commands_executed == h.output.commands_executed
+            }
+            (Err(_), Err(_)) => true, // both failed to run
+            _ => false,
+        };
+
+        let mut notes = Vec::new();
+        if let (Ok(g), Ok(h)) = (&gql, &hyb) {
+            if g.output.local_success != h.output.local_success {
+                notes.push(format!(
+                    "status differs: graphql={} hybrid={}",
+                    if g.output.local_success {
+                        "success"
+                    } else {
+                        "failed"
+                    },
+                    if h.output.local_success {
+                        "success"
+                    } else {
+                        "failed"
+                    },
+                ));
+            }
+            if g.output.commands_executed != h.output.commands_executed {
+                notes.push(format!(
+                    "commands: graphql={} hybrid={}",
+                    g.output.commands_executed, h.output.commands_executed,
+                ));
+            }
+            if g.output.local_error != h.output.local_error {
+                notes.push("error messages differ".to_string());
+            }
+        }
+
+        let source_comparison = SourceComparisonResult {
+            graphql_success: gql
+                .as_ref()
+                .map(|r| r.output.local_success)
+                .unwrap_or(false),
+            hybrid_success: hyb
+                .as_ref()
+                .map(|r| r.output.local_success)
+                .unwrap_or(false),
+            results_match,
+            graphql_error: match &gql {
+                Ok(r) => r.output.local_error.clone(),
+                Err(e) => Some(e.to_string()),
+            },
+            hybrid_error: match &hyb {
+                Ok(r) => r.output.local_error.clone(),
+                Err(e) => Some(e.to_string()),
+            },
+            graphql_api_calls: SourceApiCalls {
+                graphql: gql.as_ref().map(|r| r.graphql_requests).unwrap_or(0),
+                grpc: gql.as_ref().map(|r| r.grpc_requests).unwrap_or(0),
+            },
+            hybrid_api_calls: SourceApiCalls {
+                graphql: hyb.as_ref().map(|r| r.graphql_requests).unwrap_or(0),
+                grpc: hyb.as_ref().map(|r| r.grpc_requests).unwrap_or(0),
+            },
+            graphql_duration_ms: gql.as_ref().map(|r| r.duration.as_millis()).unwrap_or(0),
+            hybrid_duration_ms: hyb.as_ref().map(|r| r.duration.as_millis()).unwrap_or(0),
+            notes,
+        };
+
+        // Use the graphql result as primary output, attach comparison
+        let mut output = match gql {
+            Ok(r) => r.output,
+            Err(e) => ReplayOutput {
+                digest: digest.to_string(),
+                local_success: false,
+                local_error: Some(e.to_string()),
+                diagnostics: None,
+                execution_path: ReplayExecutionPath {
+                    requested_source: "compare".to_string(),
+                    effective_source: "graphql".to_string(),
+                    ..Default::default()
+                },
+                comparison: None,
+                analysis: None,
+                effects: None,
+                effects_full: None,
+                commands_executed: 0,
+                source_comparison: None,
+                batch_summary_printed: false,
+            },
+        };
+        output.source_comparison = Some(source_comparison);
+        output.execution_path.requested_source = "compare".to_string();
+        Ok(output)
+    }
+}
+
+/// Run the core replay pipeline for a single source.
+fn run_pipeline(
+    cmd: &ReplayCmd,
+    state: &SandboxState,
+    provider: &Arc<HistoricalStateProvider>,
+    replay_state_result: Result<sui_state_fetcher::ReplayState>,
+    source_label: &str,
+    allow_fallback: bool,
+    enable_dynamic_fields: bool,
+) -> Result<SingleSourceResult> {
+    let start = Instant::now();
+
+    let replay_state = replay_state_result?;
+
+    let pkg_aliases = build_aliases_shared(
+        &replay_state.packages,
+        Some(provider.as_ref()),
+        replay_state.checkpoint,
+    );
+
+    let mut resolver = hydrate_resolver_from_replay_state(
+        state,
+        &replay_state,
+        &pkg_aliases.linkage_upgrades,
+        &pkg_aliases.aliases,
+    );
+
+    let fetched_deps = fetch_dependency_closure(
+        &mut resolver,
+        provider.graphql(),
+        replay_state.checkpoint,
+        false, // quiet
+    )
+    .unwrap_or(0);
+
+    emit_linkage_debug_info(&resolver, &pkg_aliases.aliases);
+
+    let mut maps = build_replay_object_maps(&replay_state, &pkg_aliases.versions);
+    maybe_patch_replay_objects(
+        &resolver,
+        &replay_state,
+        &pkg_aliases.versions,
+        &pkg_aliases.aliases,
+        &mut maps,
+        false,
+        false,
+    );
+    let versions_str = maps.versions_str.clone();
+    let cached_objects = maps.cached_objects;
+    let version_map = maps.version_map;
+
+    let reconcile_policy = if cmd.reconcile_dynamic_fields {
+        EffectsReconcilePolicy::DynamicFields
+    } else {
+        EffectsReconcilePolicy::Strict
+    };
+
+    let config = build_simulation_config(&replay_state);
+    let mut harness = sui_sandbox_core::vm::VMHarness::with_config(&resolver, false, config)?;
+    harness.set_address_aliases_with_versions(pkg_aliases.aliases.clone(), versions_str.clone());
+
+    // Set up dynamic field fetcher if enabled
+    if enable_dynamic_fields {
+        let provider_clone = Arc::clone(provider);
+        let checkpoint = replay_state.checkpoint;
+        let max_version = version_map.values().copied().max().unwrap_or(0);
+        let fetcher =
+            move |_parent: move_core_types::account_address::AccountAddress,
+                  child_id: move_core_types::account_address::AccountAddress| {
+                fetch_child_object(&provider_clone, child_id, checkpoint, max_version)
+            };
+        harness.set_versioned_child_fetcher(Box::new(fetcher));
+    }
+
+    let replay_result = tx_replay::replay_with_version_tracking_with_policy_with_effects(
+        &replay_state.transaction,
+        &mut harness,
+        &cached_objects,
+        &pkg_aliases.aliases,
+        Some(&versions_str),
+        reconcile_policy,
+    );
+
+    let graphql_requests = provider.graphql().request_count();
+    let grpc_requests = provider.grpc().request_count();
+    let duration = start.elapsed();
+
+    match replay_result {
+        Ok(execution) => {
+            let result = execution.result;
+            let effects_summary = build_effects_summary(&execution.effects);
+            let comparison = if cmd.compare {
+                result.comparison.map(|c| ComparisonResult {
+                    status_match: c.status_match,
+                    created_match: c.created_count_match,
+                    mutated_match: c.mutated_count_match,
+                    deleted_match: c.deleted_count_match,
+                    on_chain_status: if c.status_match && result.local_success {
+                        "success".to_string()
+                    } else if c.status_match && !result.local_success {
+                        "failed".to_string()
+                    } else {
+                        "unknown".to_string()
+                    },
+                    local_status: if result.local_success {
+                        "success".to_string()
+                    } else {
+                        "failed".to_string()
+                    },
+                    notes: c.notes.clone(),
+                })
+            } else {
+                None
+            };
+            Ok(SingleSourceResult {
+                output: ReplayOutput {
+                    digest: replay_state.transaction.digest.0.clone(),
+                    local_success: result.local_success,
+                    local_error: result.local_error,
+                    diagnostics: None,
+                    execution_path: ReplayExecutionPath {
+                        requested_source: source_label.to_string(),
+                        effective_source: source_label.to_string(),
+                        allow_fallback,
+                        dynamic_field_prefetch: enable_dynamic_fields,
+                        dependency_fetch_mode: "graphql_dependency_closure".to_string(),
+                        dependency_packages_fetched: fetched_deps,
+                        graphql_requests,
+                        grpc_requests,
+                        ..Default::default()
+                    },
+                    comparison,
+                    analysis: None,
+                    effects: Some(effects_summary),
+                    effects_full: Some(execution.effects),
+                    commands_executed: result.commands_executed,
+                    source_comparison: None,
+                    batch_summary_printed: false,
+                },
+                graphql_requests,
+                grpc_requests,
+                duration,
+            })
+        }
+        Err(e) => Ok(SingleSourceResult {
+            output: ReplayOutput {
+                digest: replay_state.transaction.digest.0.clone(),
+                local_success: false,
+                local_error: Some(e.to_string()),
+                diagnostics: None,
+                execution_path: ReplayExecutionPath {
+                    requested_source: source_label.to_string(),
+                    effective_source: source_label.to_string(),
+                    allow_fallback,
+                    dynamic_field_prefetch: enable_dynamic_fields,
+                    dependency_fetch_mode: "graphql_dependency_closure".to_string(),
+                    dependency_packages_fetched: fetched_deps,
+                    graphql_requests,
+                    grpc_requests,
+                    ..Default::default()
+                },
+                comparison: None,
+                analysis: None,
+                effects: None,
+                effects_full: None,
+                commands_executed: 0,
+                source_comparison: None,
+                batch_summary_printed: false,
+            },
+            graphql_requests,
+            grpc_requests,
+            duration,
+        }),
+    }
+}

--- a/src/bin/sandbox_cli/replay/dynamic_fields.rs
+++ b/src/bin/sandbox_cli/replay/dynamic_fields.rs
@@ -263,6 +263,25 @@ pub(super) fn fetch_child_object_by_key(
         }
     }
 
+    // Fallback: use objectVersionsBefore when @snapshot fails or version exceeds max
+    if max_version > 0 {
+        if let Ok(obj) = gql.fetch_object_version_before(&child_hex, max_version + 1) {
+            if let (Some(type_str), Some(bcs_b64)) = (obj.type_string, obj.bcs_base64) {
+                if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(&bcs_b64) {
+                    if let Ok(tag) = parse_type_tag(&type_str) {
+                        if debug_df {
+                            eprintln!(
+                                "[df_fetch] version_before child={} version={} type={}",
+                                child_hex, obj.version, type_str
+                            );
+                        }
+                        return Some((tag, bytes));
+                    }
+                }
+            }
+        }
+    }
+
     let parent_hex = parent_id.to_hex_literal();
     let miss_key = miss_cache.map(|_| {
         let key_type_str = format_type_tag(key_type);
@@ -450,7 +469,10 @@ pub(super) fn fetch_child_object_by_key(
                         }
                     }
                 }
-                if self_heal_dynamic_fields {
+                // Try fetching the computed child ID via GraphQL.
+                // This is needed when the locally computed hash differs from the
+                // original child ID due to package address aliasing.
+                {
                     if let Some((tag, bytes, _)) =
                         fetch_child_object_shared(provider, computed_id, checkpoint, max_version)
                     {

--- a/src/bin/sandbox_cli/replay/effects.rs
+++ b/src/bin/sandbox_cli/replay/effects.rs
@@ -12,6 +12,8 @@ pub(super) fn build_execution_path(
     fallback_used: bool,
     fallback_reasons: Vec<String>,
     synthetic_inputs: usize,
+    graphql_requests: u64,
+    grpc_requests: u64,
 ) -> ReplayExecutionPath {
     ReplayExecutionPath {
         requested_source: cmd
@@ -35,6 +37,8 @@ pub(super) fn build_execution_path(
         dependency_fetch_mode,
         dependency_packages_fetched: fetched_deps,
         synthetic_inputs,
+        graphql_requests,
+        grpc_requests,
     }
 }
 

--- a/src/bin/sandbox_cli/replay/execute_state.rs
+++ b/src/bin/sandbox_cli/replay/execute_state.rs
@@ -179,12 +179,14 @@ pub(super) fn execute_replay_state(
                     dependency_fetch_mode: effective_source.to_string(),
                     dependency_packages_fetched: 0,
                     synthetic_inputs: 0,
+                    ..Default::default()
                 },
                 comparison,
                 analysis: None,
                 effects: Some(effects_summary),
                 effects_full: Some(execution.effects),
                 commands_executed: result.commands_executed,
+                source_comparison: None,
                 batch_summary_printed: false,
             })
         }
@@ -210,12 +212,14 @@ pub(super) fn execute_replay_state(
                     dependency_fetch_mode: effective_source.to_string(),
                     dependency_packages_fetched: 0,
                     synthetic_inputs: 0,
+                    ..Default::default()
                 },
                 comparison: None,
                 analysis: None,
                 effects: None,
                 effects_full: None,
                 commands_executed: 0,
+                source_comparison: None,
                 batch_summary_printed: false,
             })
         }

--- a/src/bin/sandbox_cli/replay/presentation.rs
+++ b/src/bin/sandbox_cli/replay/presentation.rs
@@ -81,6 +81,12 @@ pub(super) fn print_replay_result(result: &ReplayOutput, show_comparison: bool, 
         result.execution_path.dependency_fetch_mode,
         result.execution_path.dependency_packages_fetched
     );
+    if result.execution_path.graphql_requests > 0 || result.execution_path.grpc_requests > 0 {
+        println!(
+            "  API calls: graphql={} grpc={}",
+            result.execution_path.graphql_requests, result.execution_path.grpc_requests
+        );
+    }
 
     if show_comparison {
         if let Some(cmp) = &result.comparison {
@@ -121,6 +127,53 @@ pub(super) fn print_replay_result(result: &ReplayOutput, show_comparison: bool, 
             );
         } else {
             println!("\n\x1b[33mNote: No on-chain effects available for comparison\x1b[0m");
+        }
+    }
+
+    if let Some(src) = &result.source_comparison {
+        println!("\n\x1b[1mSource Comparison (GraphQL vs Hybrid):\x1b[0m");
+        println!(
+            "  Results: {}",
+            if src.results_match {
+                "\x1b[32m\u{2713} match\x1b[0m"
+            } else {
+                "\x1b[31m\u{2717} mismatch\x1b[0m"
+            }
+        );
+        println!(
+            "  GraphQL: {} ({}ms, gql={} grpc={})",
+            if src.graphql_success {
+                "\x1b[32msuccess\x1b[0m"
+            } else {
+                "\x1b[31mfailed\x1b[0m"
+            },
+            src.graphql_duration_ms,
+            src.graphql_api_calls.graphql,
+            src.graphql_api_calls.grpc,
+        );
+        println!(
+            "  Hybrid:  {} ({}ms, gql={} grpc={})",
+            if src.hybrid_success {
+                "\x1b[32msuccess\x1b[0m"
+            } else {
+                "\x1b[31mfailed\x1b[0m"
+            },
+            src.hybrid_duration_ms,
+            src.hybrid_api_calls.graphql,
+            src.hybrid_api_calls.grpc,
+        );
+        if !src.notes.is_empty() {
+            for note in &src.notes {
+                println!("  Note: {}", note);
+            }
+        }
+        if !src.results_match {
+            if let Some(err) = &src.graphql_error {
+                println!("  GraphQL error: {}", err);
+            }
+            if let Some(err) = &src.hybrid_error {
+                println!("  Hybrid error: {}", err);
+            }
         }
     }
 }
@@ -293,6 +346,7 @@ mod tests {
             effects: None,
             effects_full: None,
             commands_executed: 0,
+            source_comparison: None,
             batch_summary_printed: false,
         };
 

--- a/src/bin/sandbox_cli/replay/walrus_batch.rs
+++ b/src/bin/sandbox_cli/replay/walrus_batch.rs
@@ -205,6 +205,7 @@ pub(super) async fn execute_walrus_batch_v2(
                 state_json: None,
                 export_state: None,
                 latest: None,
+                compare_sources: false,
             };
 
             let output = single


### PR DESCRIPTION
## Summary
- replace remaining historical GraphQL `@snapshot` queries with the current public-schema checkpoint APIs (`atCheckpoint` / `package`) and remove incorrect fallbacks to latest state for historical lookups
- carry forward the replay/debugging work in the existing tree, including GraphQL vs hybrid comparison output and GraphQL/gRPC request counting
- fold in the repo baseline fixes needed to make CI pass locally: Python version sync, markdown link checking under `node_modules`, workspace formatting, and a more robust Node smoke test artifact lookup

## Validation
- `python scripts/check_python_versions.py`
- `python scripts/check_markdown_links.py --base .`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features --exclude sui-python --exclude sui-napi -- -D warnings`
- `cargo test --locked --workspace --tests --exclude sui-python --exclude sui-napi`
- `./scripts/rust_examples_smoke.sh`
- `python3.13 -m venv /tmp/sui-sandbox-ci-venv`
- `/tmp/sui-sandbox-ci-venv/bin/maturin build --manifest-path crates/sui-python/Cargo.toml --release -i /tmp/sui-sandbox-ci-venv/bin/python -o dist`
- Python smoke and example compatibility checks from `.github/workflows/ci.yml`
- `npm install` and `npx napi build --release --platform` in `crates/sui-napi`, plus the Node smoke check using the built `.node` artifact
- `cargo check -p sui-sandbox-core`
- `cargo check -p sui-sandbox`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check -p sui-python --tests`
- `cargo test -p sui-sandbox workflow -- --test-threads=1`
- `cargo test -p sui-sandbox-core workflow_planner -- --test-threads=1`
